### PR TITLE
[Fix] 배포 페이지에서 StudioPage 404 오류 해결

### DIFF
--- a/Frontend/netlify.toml
+++ b/Frontend/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## 📝 PR 설명
배포한 페이지에서 StudioPage 404 오류 해결

## ✅ 주요 변경 사항
* Navbar a태그 -> NavLink
* netlify.toml 추가


## 📸 스크린샷 (선택)

## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)
