### PR TITLE
[Refactor] 컴포넌트 분리, 버그 수정

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
         "react-router-dom": "^6.27.0",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "zustand": "^5.0.1"
       },
       "devDependencies": {
@@ -6023,6 +6024,11 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.14",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.27.0",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/Frontend/src/components/VideoPlayer/Control/SettingsControl.tsx
+++ b/Frontend/src/components/VideoPlayer/Control/SettingsControl.tsx
@@ -1,0 +1,38 @@
+import { useState, useRef } from 'react';
+import { LuSettings } from 'react-icons/lu';
+
+interface SettingsControlProps {
+  onShowControls: () => void;
+}
+
+export default function SettingsControl({ onShowControls }: SettingsControlProps) {
+  const [showSettings, setShowSettings] = useState(false);
+  const settingsControlRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={settingsControlRef} className="relative flex items-center">
+      <button
+        type="button"
+        onClick={() => {
+          setShowSettings(!showSettings);
+          onShowControls();
+        }}
+        className="hover:text-lico-gray-2"
+        aria-label="설정"
+        aria-expanded={showSettings}
+        aria-controls="settings-menu"
+      >
+        <LuSettings size={18} />
+      </button>
+      {showSettings && (
+        <div className="absolute bottom-5 right-0 rounded bg-black/50 font-medium text-sm text-lico-gray-2">
+          <p className="hover:text-lico-gray-1">auto</p>
+          <p className="hover:text-lico-gray-1">1080p</p>
+          <p className="hover:text-lico-gray-1">720p</p>
+          <p className="hover:text-lico-gray-1">480p</p>
+          <p className="hover:text-lico-gray-1">360p</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Frontend/src/components/VideoPlayer/Control/VolumeControl.tsx
+++ b/Frontend/src/components/VideoPlayer/Control/VolumeControl.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useRef } from 'react';
+import { LuVolumeX, LuVolume2 } from 'react-icons/lu';
+
+interface VolumeControlProps {
+  volume: number;
+  isMuted: boolean;
+  onVolumeChange: (volume: number) => void;
+  onMuteToggle: () => void;
+  onShowControls: () => void;
+}
+
+export default function VolumeControl({
+  volume,
+  isMuted,
+  onVolumeChange,
+  onMuteToggle,
+  onShowControls,
+}: VolumeControlProps) {
+  const [showVolumeSlider, setShowVolumeSlider] = useState(false);
+  const volumeControlRef = useRef<HTMLDivElement>(null);
+
+  const handleVolume = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newVolume = parseFloat(e.target.value) / 10;
+    onVolumeChange(newVolume);
+  };
+
+  return (
+    <div
+      ref={volumeControlRef}
+      className="relative flex items-center gap-2"
+      onMouseEnter={() => {
+        setShowVolumeSlider(true);
+        onShowControls();
+      }}
+    >
+      <button
+        type="button"
+        onClick={onMuteToggle}
+        className="hover:text-lico-gray-2"
+        aria-label={isMuted ? '음소거 해제' : '음소거'}
+        aria-pressed={isMuted}
+      >
+        {isMuted ? <LuVolumeX size={18} /> : <LuVolume2 size={18} />}
+      </button>
+      <div
+        className={`absolute bottom-[1px] left-6 transition-opacity duration-200 ${
+          showVolumeSlider ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        role="group"
+        aria-label="볼륨 조절"
+      >
+        <input
+          type="range"
+          min="0"
+          max="10"
+          step="0.1"
+          value={isMuted ? 0 : volume * 10}
+          onChange={handleVolume}
+          className="h-1 w-32 cursor-pointer appearance-none bg-transparent"
+          style={{
+            background: `linear-gradient(to right, #FF6B34 0%, #FF6B34 ${
+              (isMuted ? 0 : volume) * 100
+            }%, #B0B0B0 ${(isMuted ? 0 : volume) * 100}%, #B0B0B0 100%)`,
+            outline: 'none',
+            borderRadius: '4px',
+          }}
+          aria-label="볼륨"
+          aria-valuemin={0}
+          aria-valuemax={10}
+          aria-valuenow={isMuted ? 0 : volume * 10}
+          aria-valuetext={`볼륨 ${Math.round(isMuted ? 0 : volume * 100)}%`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/components/VideoPlayer/Control/index.tsx
+++ b/Frontend/src/components/VideoPlayer/Control/index.tsx
@@ -1,0 +1,87 @@
+import { LuPlay, LuPause, LuMinimize, LuMaximize, LuTv2 } from 'react-icons/lu';
+import VolumeControl from './VolumeControl';
+import SettingsControl from './SettingsControl';
+
+interface ControlsProps {
+  isPlaying: boolean;
+  isFullScreen: boolean;
+  videoPlayerState: string;
+  showControls: boolean;
+  volume: number;
+  isMuted: boolean;
+  onPlayToggle: () => void;
+  onVolumeChange: (volume: number) => void;
+  onMuteToggle: () => void;
+  onFullScreenToggle: () => void;
+  onVideoPlayerToggle: () => void;
+  onShowControls: () => void;
+}
+
+export default function Controls({
+  isPlaying,
+  isFullScreen,
+  videoPlayerState,
+  showControls,
+  volume,
+  isMuted,
+  onPlayToggle,
+  onVolumeChange,
+  onMuteToggle,
+  onFullScreenToggle,
+  onVideoPlayerToggle,
+  onShowControls,
+}: ControlsProps) {
+  return (
+    <div
+      className={`absolute bottom-0 left-0 right-0 p-4 text-lico-gray-1 transition-opacity duration-300 ${
+        showControls ? 'opacity-100' : 'pointer-events-none opacity-0'
+      }`}
+      role="toolbar"
+      aria-label="비디오 컨트롤"
+    >
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={onPlayToggle}
+          className="hover:text-lico-gray-2"
+          aria-label={isPlaying ? '일시정지' : '재생'}
+          aria-pressed={isPlaying}
+        >
+          {isPlaying ? <LuPause size={18} /> : <LuPlay size={18} />}
+        </button>
+
+        <VolumeControl
+          volume={volume}
+          isMuted={isMuted}
+          onVolumeChange={onVolumeChange}
+          onMuteToggle={onMuteToggle}
+          onShowControls={onShowControls}
+        />
+
+        <div className="relative ml-auto flex items-center gap-4">
+          <SettingsControl onShowControls={onShowControls} />
+
+          <button
+            type="button"
+            onClick={onVideoPlayerToggle}
+            className="hover:text-lico-gray-2"
+            aria-label={isFullScreen ? '극장모드 종료' : '극장모드'}
+            aria-pressed={isFullScreen}
+          >
+            <LuTv2 size={18} />
+          </button>
+
+          <button
+            type="button"
+            onClick={onFullScreenToggle}
+            className="hover:text-lico-gray-2"
+            aria-label={videoPlayerState === 'theater' ? '전체화면 종료' : '전체화면'}
+            aria-pressed={videoPlayerState === 'theater'}
+          >
+            {isFullScreen ? <LuMinimize size={18} /> : <LuMaximize size={18} />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { LuPlay, LuPause, LuVolumeX, LuVolume2, LuSettings, LuMinimize, LuMaximize, LuTv2 } from 'react-icons/lu';
 import useLayoutStore from '@store/useLayoutStore';
+import Controls from './Control/index';
 
 interface VideoPlayerProps {
   streamUrl: string;
@@ -11,17 +11,12 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
   const [volume, setVolume] = useState(1);
   const [isMuted, setIsMuted] = useState(false);
   const [isFullScreen, setIsFullScreen] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
-  const [showVolumeSlider, setShowVolumeSlider] = useState(false);
-  const [isVolumeHovered, setIsVolumeHovered] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [showCursor, setShowCursor] = useState(true);
-  const { toggleVideoPlayer } = useLayoutStore();
 
+  const { videoPlayerState, toggleVideoPlayer } = useLayoutStore();
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const volumeControlRef = useRef<HTMLDivElement>(null);
-  const settingsControlRef = useRef<HTMLDivElement>(null);
   const controlsTimeoutRef = useRef<NodeJS.Timeout>();
 
   const togglePlay = () => {
@@ -35,8 +30,7 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
     }
   };
 
-  const handleVolume = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newVolume = parseFloat(e.target.value) / 10;
+  const handleVolumeChange = (newVolume: number) => {
     setVolume(newVolume);
     if (videoRef.current) {
       videoRef.current.volume = newVolume;
@@ -69,8 +63,6 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
   const hideAllControls = () => {
     setShowControls(false);
     setShowCursor(false);
-    setShowSettings(false);
-    setShowVolumeSlider(false);
   };
 
   const startControlsTimer = () => {
@@ -80,10 +72,14 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
     controlsTimeoutRef.current = setTimeout(hideAllControls, 3000);
   };
 
-  const handleMouseMove = () => {
+  const handleShowControls = () => {
     setShowControls(true);
     setShowCursor(true);
     startControlsTimer();
+  };
+
+  const handleMouseMove = () => {
+    handleShowControls();
   };
 
   const handleMouseLeave = () => {
@@ -92,7 +88,6 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
     }
     hideAllControls();
     setShowCursor(true);
-    setIsVolumeHovered(false);
   };
 
   useEffect(() => {
@@ -105,23 +100,6 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
       document.removeEventListener('fullscreenchange', handleFullScreenChange);
     };
   }, []);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (volumeControlRef.current && !volumeControlRef.current.contains(event.target as Node) && !isVolumeHovered) {
-        setShowVolumeSlider(false);
-      }
-
-      if (settingsControlRef.current && !settingsControlRef.current.contains(event.target as Node)) {
-        setShowSettings(false);
-      }
-    };
-
-    document.addEventListener('click', handleClickOutside);
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, [isVolumeHovered]);
 
   useEffect(() => {
     return () => {
@@ -140,92 +118,24 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
     >
       <video ref={videoRef} className="h-full w-full bg-black" autoPlay playsInline>
         <source src={streamUrl} type="application/x-mpegURL" />
+        <track kind="captions" src="" />
         브라우저가 비디오 재생을 지원하지 않습니다.
       </video>
 
-      <div
-        className={`absolute bottom-0 left-0 right-0 p-4 text-lico-gray-1 transition-opacity duration-300 ${showControls ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
-      >
-        <div className="flex items-center gap-4">
-          <button onClick={togglePlay} className="hover:text-lico-gray-2">
-            {isPlaying ? <LuPause size={18} /> : <LuPlay size={18} />}
-          </button>
-
-          <div
-            ref={volumeControlRef}
-            className="relative flex items-center gap-2"
-            onMouseEnter={() => {
-              setShowVolumeSlider(true);
-              setIsVolumeHovered(true);
-              setShowControls(true);
-              setShowCursor(true);
-              startControlsTimer();
-            }}
-            onMouseLeave={() => {
-              setIsVolumeHovered(false);
-            }}
-          >
-            <button onClick={toggleMute} className="hover:text-lico-gray-2">
-              {isMuted ? <LuVolumeX size={18} /> : <LuVolume2 size={18} />}
-            </button>
-            <div
-              className={`absolute bottom-[1px] left-6 transition-opacity duration-200 ${
-                showVolumeSlider ? 'opacity-100' : 'pointer-events-none opacity-0'
-              }`}
-            >
-              <input
-                type="range"
-                min="0"
-                max="10"
-                step="0.1"
-                value={isMuted ? 0 : volume * 10}
-                onChange={handleVolume}
-                className="h-1 w-32 cursor-pointer appearance-none bg-transparent"
-                style={{
-                  background: `linear-gradient(to right, #FF6B34 0%, #FF6B34 ${
-                    (isMuted ? 0 : volume) * 100
-                  }%, #B0B0B0 ${(isMuted ? 0 : volume) * 100}%, #B0B0B0 100%)`,
-                  outline: 'none',
-                  borderRadius: '4px',
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="relative ml-auto flex items-center gap-4">
-            <div ref={settingsControlRef} className="relative flex items-center">
-              <button
-                onClick={() => {
-                  setShowSettings(!showSettings);
-                  setShowControls(true);
-                  setShowCursor(true);
-                  startControlsTimer();
-                }}
-                className="hover:text-lico-gray-2"
-              >
-                <LuSettings size={18} />
-              </button>
-              {showSettings && (
-                <div className="absolute bottom-5 right-0 rounded bg-black/50 font-medium text-sm text-lico-gray-2">
-                  <p className="hover:text-lico-gray-1">auto</p>
-                  <p className="hover:text-lico-gray-1">1080p</p>
-                  <p className="hover:text-lico-gray-1">720p</p>
-                  <p className="hover:text-lico-gray-1">480p</p>
-                  <p className="hover:text-lico-gray-1">360p</p>
-                </div>
-              )}
-            </div>
-
-            <button onClick={toggleVideoPlayer} className="hover:text-lico-gray-2">
-              <LuTv2 size={18} />
-            </button>
-
-            <button onClick={toggleFullScreen} className="hover:text-lico-gray-2">
-              {isFullScreen ? <LuMinimize size={18} /> : <LuMaximize size={18} />}
-            </button>
-          </div>
-        </div>
-      </div>
+      <Controls
+        isPlaying={isPlaying}
+        isFullScreen={isFullScreen}
+        videoPlayerState={videoPlayerState}
+        showControls={showControls}
+        volume={volume}
+        isMuted={isMuted}
+        onPlayToggle={togglePlay}
+        onVolumeChange={handleVolumeChange}
+        onMuteToggle={toggleMute}
+        onFullScreenToggle={toggleFullScreen}
+        onVideoPlayerToggle={toggleVideoPlayer}
+        onShowControls={handleShowControls}
+      />
     </div>
   );
 }

--- a/Frontend/src/components/chat/ChatInput.tsx
+++ b/Frontend/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { LuSend } from 'react-icons/lu';
-import { CHAT_INPUT_TEXTAREA_CLASSES, CHAT_INPUT_LINE_HEIGHT, CHAT_INPUT_MAX_ROWS } from './constants';
+import { CHAT_INPUT_TEXTAREA_CLASSES, CHAT_INPUT_LINE_HEIGHT, CHAT_INPUT_MAX_ROWS } from '@constants/chat/input';
 
 type ChatInputProps = {
   onSubmit: (message: string) => void;

--- a/Frontend/src/components/chat/ChatInput.tsx
+++ b/Frontend/src/components/chat/ChatInput.tsx
@@ -54,7 +54,7 @@ export default function ChatInput({ onSubmit }: ChatInputProps) {
           onKeyDown={handleKeyDown}
           placeholder="채팅을 입력해주세요"
           spellCheck={false}
-          className={`${CHAT_INPUT_TEXTAREA_CLASSES.base} ${CHAT_INPUT_TEXTAREA_CLASSES.focus} ${message ? CHAT_INPUT_TEXTAREA_CLASSES.active : 'bg-lico-gray-5'}`}
+          className={`${CHAT_INPUT_TEXTAREA_CLASSES.base} scrollbar-hide ${CHAT_INPUT_TEXTAREA_CLASSES.focus} ${message ? CHAT_INPUT_TEXTAREA_CLASSES.active : 'bg-lico-gray-5'}`}
         />
         <div className="mt-2 flex justify-end">
           <button

--- a/Frontend/src/components/chat/ChatWindow.tsx
+++ b/Frontend/src/components/chat/ChatWindow.tsx
@@ -71,18 +71,20 @@ export default function ChatWindow() {
           ))}
         </div>
         <div ref={bottomRef} />
+      </div>
+      <div className="relative">
         {showScrollButton && (
           <button
             aria-label="최신 메시지로 이동"
             type="button"
             onClick={scrollToBottom}
-            className="absolute bottom-24 right-4 rounded-full bg-lico-orange-2 p-2 text-sm text-lico-gray-1 opacity-75 shadow-lg hover:bg-lico-orange-1"
+            className="absolute -top-10 right-4 rounded-full bg-lico-orange-2 p-2 text-sm text-lico-gray-1 opacity-75 shadow-lg hover:bg-lico-orange-1"
           >
             <FaAngleDown />
           </button>
         )}
+        <ChatInput onSubmit={handleNewMessage} />
       </div>
-      <ChatInput onSubmit={handleNewMessage} />
     </div>
   );
 }

--- a/Frontend/src/components/chat/ChatWindow.tsx
+++ b/Frontend/src/components/chat/ChatWindow.tsx
@@ -4,7 +4,7 @@ import { FaAngleDown } from 'react-icons/fa';
 import ChatHeader from '@components/chat/ChatHeader';
 import ChatInput from '@components/chat/ChatInput';
 import useLayoutStore from '@store/useLayoutStore';
-import { getConsistentTextColor, createTestChatMessage } from './utils';
+import { getConsistentTextColor, createTestChatMessage } from '@utils/chatUtils';
 import ChatMessage from './ChatMessage';
 
 export default function ChatWindow() {

--- a/Frontend/src/components/chat/ChatWindow.tsx
+++ b/Frontend/src/components/chat/ChatWindow.tsx
@@ -58,11 +58,7 @@ export default function ChatWindow() {
         aria-label="채팅 메시지"
         aria-live="polite"
         ref={chatRef}
-        className="h-screen overflow-auto p-4"
-        style={{
-          scrollbarWidth: 'none',
-          msOverflowStyle: 'none',
-        }}
+        className="scrollbar-hide h-screen overflow-auto p-4"
       >
         <div className="flex break-after-all flex-col gap-2.5">
           {messages.map(message => (

--- a/Frontend/src/components/common/Buttons/ChatOpenButton.tsx
+++ b/Frontend/src/components/common/Buttons/ChatOpenButton.tsx
@@ -2,15 +2,16 @@ import { LuArrowLeftToLine } from 'react-icons/lu';
 
 interface ChatOpenButtonProps {
   onClick: () => void;
+  className?: string;
 }
 
-export default function ChatOpenButton({ onClick }: ChatOpenButtonProps) {
+export default function ChatOpenButton({ onClick, className = 'text-lico-gray-1' }: ChatOpenButtonProps) {
   return (
     <button
       aria-label="채팅창 열기"
       type="button"
       onClick={onClick}
-      className="fixed right-2 top-4 z-10 text-lico-gray-1"
+      className={`fixed right-2 top-4 z-10 ${className}`}
     >
       <LuArrowLeftToLine size={20} />
     </button>

--- a/Frontend/src/components/common/Buttons/FollowButton.tsx
+++ b/Frontend/src/components/common/Buttons/FollowButton.tsx
@@ -1,6 +1,6 @@
 import { LuHeart, LuHeartOff } from 'react-icons/lu';
 import { FaHeart } from 'react-icons/fa';
-import useStore from '@/store/useStore';
+import useFollowStore from '@store/useFollowStore.ts';
 import { useState } from 'react';
 
 interface FollowButtonProps {
@@ -8,7 +8,7 @@ interface FollowButtonProps {
 }
 
 export default function FollowButton({ channelId }: FollowButtonProps) {
-  const { followingChannels, followChannel, unfollowChannel } = useStore();
+  const { followingChannels, followChannel, unfollowChannel } = useFollowStore();
   const isFollowing = followingChannels.includes(channelId);
   const [isHovered, setIsHovered] = useState(false);
 
@@ -28,6 +28,7 @@ export default function FollowButton({ channelId }: FollowButtonProps) {
         </div>
       )}
       <button
+        type="button"
         onClick={handleClick}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}

--- a/Frontend/src/constants/chat/color.ts
+++ b/Frontend/src/constants/chat/color.ts
@@ -1,0 +1,12 @@
+export const TAILWIND_USER_COLORS = [
+  'text-rose-500', // 붉은색
+  'text-orange-500', // 주황색
+  'text-amber-500', // 황색
+  'text-lime-500', // 라임색
+  'text-emerald-500', // 에메랄드색
+  'text-cyan-500', // 시안색
+  'text-blue-500', // 파란색
+  'text-violet-500', // 보라색
+  'text-purple-500', // 자주색
+  'text-pink-500', // 분홍색
+] as const;

--- a/Frontend/src/constants/chat/input.ts
+++ b/Frontend/src/constants/chat/input.ts
@@ -1,16 +1,3 @@
-export const TAILWIND_USER_COLORS = [
-  'text-rose-500', // 붉은색
-  'text-orange-500', // 주황색
-  'text-amber-500', // 황색
-  'text-lime-500', // 라임색
-  'text-emerald-500', // 에메랄드색
-  'text-cyan-500', // 시안색
-  'text-blue-500', // 파란색
-  'text-violet-500', // 보라색
-  'text-purple-500', // 자주색
-  'text-pink-500', // 분홍색
-] as const;
-
 export const CHAT_INPUT_TEXTAREA_CLASSES = {
   base: 'flex-1 resize-none rounded-md border border-lico-gray-3 px-2 py-1 font-medium text-sm text-lico-gray-1',
   focus: 'focus:border-transparent focus:bg-lico-gray-4 focus:outline-none focus:ring-2 focus:ring-lico-orange-2',

--- a/Frontend/src/layouts/Layout.tsx
+++ b/Frontend/src/layouts/Layout.tsx
@@ -12,11 +12,7 @@ export default function Layout() {
     <div className="flex h-screen">
       {isHidden ? '' : isCollapsed ? <NavbarMini /> : <Navbar />}
       <main
-        className={`${!isHidden && 'ml-60'} ${isCollapsed && 'ml-[92px]'} flex-1 overflow-auto bg-lico-gray-5`}
-        style={{
-          scrollbarWidth: 'none',
-          msOverflowStyle: 'none',
-        }}
+        className={`${!isHidden && 'ml-60'} ${isCollapsed && 'ml-[92px]'} scrollbar-hider flex-1 overflow-auto bg-lico-gray-5`}
       >
         <Outlet />
       </main>

--- a/Frontend/src/pages/FollowingPage/index.tsx
+++ b/Frontend/src/pages/FollowingPage/index.tsx
@@ -1,11 +1,11 @@
-import useStore from '@/store/useStore';
+import useFollowStore from '@store/useFollowStore.ts';
 import mockChannels from '@/mocks/mockChannels';
 import mockUsers from '@/mocks/mockUsers';
 import ChannelGrid from '@/components/channel/ChannelGrid';
 import type { ChannelCardProps } from '@/components/channel/ChannelCard';
 
 export default function FollowingPage() {
-  const { followingChannels } = useStore();
+  const { followingChannels } = useFollowStore();
 
   const followedChannels = followingChannels
     .map(channelId => {

--- a/Frontend/src/pages/LivePage/index.tsx
+++ b/Frontend/src/pages/LivePage/index.tsx
@@ -28,13 +28,13 @@ export default function LivePage() {
     } else {
       handleBreakpoint('CHAT_HIDDEN');
     }
-  }, [isLarge, isMedium]);
+  }, [isLarge, isMedium, handleBreakpoint]);
 
   useEffect(() => {
     if (!currentChannel && id) {
       const channel = mockChannels.find(channel => channel.id === id);
       const user = mockUsers[id];
-      const categoryData = mockCategories.find(cat => cat.id === channel?.category);
+      const categoryData = mockCategories.find(cat => cat.id === channel?.categoryId);
 
       if (channel && user && categoryData) {
         setCurrentChannel({
@@ -78,13 +78,7 @@ export default function LivePage() {
   return (
     <div className="flex h-screen">
       <div className="flex-1">
-        <div
-          className="flex h-full flex-col overflow-y-auto"
-          style={{
-            scrollbarWidth: 'none',
-            msOverflowStyle: 'none',
-          }}
-        >
+        <div className="scrollbar-hide flex h-full flex-col overflow-y-auto">
           <VideoPlayer streamUrl="" />
           <LiveInfo channelId={id} />
           <StreamerInfo />

--- a/Frontend/src/pages/StudioPage/ControlButton.tsx
+++ b/Frontend/src/pages/StudioPage/ControlButton.tsx
@@ -1,0 +1,25 @@
+import { IconType } from 'react-icons';
+
+interface ControlButtonProps {
+  icon: IconType;
+  label: string;
+  isEnabled: boolean;
+  onClick: () => void;
+}
+
+export default function ControlButton({ icon: Icon, label, isEnabled, onClick }: ControlButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
+        isEnabled ? 'bg-lico-orange-2 text-lico-gray-5' : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
+      }`}
+      aria-pressed={isEnabled}
+      aria-label={label}
+    >
+      <Icon className="-mt-0.5 h-4 w-4" aria-hidden="true" />
+      {label}
+    </button>
+  );
+}

--- a/Frontend/src/pages/StudioPage/StreamInfo.tsx
+++ b/Frontend/src/pages/StudioPage/StreamInfo.tsx
@@ -1,0 +1,78 @@
+import { LuSearch } from 'react-icons/lu';
+
+export default function StreamInfo() {
+  return (
+    <form className="flex flex-col gap-6" aria-label="방송 정보 설정">
+      <div>
+        <label htmlFor="title" className="mb-2 block font-bold text-lico-gray-1">
+          방송 제목
+        </label>
+        <input
+          id="title"
+          type="text"
+          className="w-full rounded bg-lico-gray-5 p-2 font-medium text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
+          aria-label="방송 제목"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="description" className="mb-2 block font-bold text-lico-gray-1">
+          방송 설명
+        </label>
+        <textarea
+          id="description"
+          className="h-24 w-full resize-none overflow-y-auto rounded bg-lico-gray-5 p-2 font-medium text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
+          aria-label="방송 설명"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="category" className="mb-2 block font-bold text-lico-gray-1">
+          카테고리
+        </label>
+        <div className="relative">
+          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <LuSearch className="h-4 w-4 text-lico-gray-2" aria-hidden="true" />
+          </div>
+          <input
+            id="category"
+            type="text"
+            className="w-full rounded bg-lico-gray-5 py-2 pl-9 pr-2 font-medium text-sm text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
+            placeholder="카테고리 검색"
+            aria-label="카테고리 검색"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="tags" className="mb-2 block font-bold text-lico-gray-1">
+          태그<span className="text-lico-gray-2"> (최대 5개)</span>
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="tags"
+            type="text"
+            className="flex-1 rounded bg-lico-gray-5 p-2 font-medium text-sm text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
+            placeholder="태그 입력"
+            aria-label="태그 입력"
+          />
+          <button
+            type="button"
+            className="whitespace-nowrap rounded-md bg-lico-gray-3 px-3 py-2 font-medium text-sm text-lico-gray-1 hover:bg-lico-gray-1 hover:text-lico-orange-2"
+            aria-label="태그 추가"
+          >
+            추가
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        className="flex items-center justify-center gap-2 rounded bg-lico-orange-2 px-4 py-2 font-bold text-lico-gray-5 transition-colors hover:bg-lico-orange-1"
+        aria-label="방송 정보 업데이트"
+      >
+        업데이트
+      </button>
+    </form>
+  );
+}

--- a/Frontend/src/pages/StudioPage/StreamSettings.tsx
+++ b/Frontend/src/pages/StudioPage/StreamSettings.tsx
@@ -1,0 +1,73 @@
+import { LuCopy, LuEye, LuEyeOff } from 'react-icons/lu';
+
+interface StreamSettingsProps {
+  showStreamKey: boolean;
+  setShowStreamKey: (show: boolean) => void;
+}
+
+export default function StreamSettings({ showStreamKey, setShowStreamKey }: StreamSettingsProps) {
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <div className="mt-4 space-y-4">
+      <div>
+        <label htmlFor="streamUrl" className="mb-2 block font-bold text-sm text-lico-gray-1">
+          스트림 URL
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="streamUrl"
+            type="text"
+            readOnly
+            className="flex-1 rounded bg-lico-gray-4 p-2 font-medium text-sm text-lico-gray-1 outline-none"
+            value="rtmp://stream.example.com/live"
+            aria-label="스트림 URL"
+          />
+          <button
+            type="button"
+            onClick={() => copyToClipboard('rtmp://stream.example.com/live')}
+            className="flex items-center justify-center rounded bg-lico-gray-3 px-3 text-lico-gray-1 hover:bg-lico-gray-1 hover:text-lico-orange-2"
+            aria-label="스트림 URL 복사"
+          >
+            <LuCopy className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      <div>
+        <label htmlFor="streamKey" className="mb-2 block font-bold text-sm text-lico-gray-1">
+          스트림 키
+        </label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <input
+              id="streamKey"
+              type={showStreamKey ? 'text' : 'password'}
+              readOnly
+              className="w-full rounded bg-lico-gray-4 p-2 font-medium text-sm text-lico-gray-1 outline-none"
+              value="xxxx-xxxx-xxxx-xxxx"
+              aria-label="스트림 키"
+            />
+            <button
+              type="button"
+              onClick={() => setShowStreamKey(!showStreamKey)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-lico-gray-1 hover:text-lico-orange-2"
+              aria-label={showStreamKey ? '스트림 키 숨기기' : '스트림 키 보기'}
+            >
+              {showStreamKey ? <LuEyeOff className="h-4 w-4" /> : <LuEye className="h-4 w-4" />}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => copyToClipboard('xxxx-xxxx-xxxx-xxxx')}
+            className="flex items-center justify-center rounded bg-lico-gray-3 px-3 text-lico-gray-1 hover:bg-lico-gray-1 hover:text-lico-orange-2"
+            aria-label="스트림 키 복사"
+          >
+            <LuCopy className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/pages/StudioPage/WebStreamControls.tsx
+++ b/Frontend/src/pages/StudioPage/WebStreamControls.tsx
@@ -29,7 +29,7 @@ export default function WebStreamControls({
   setDrawEnabled,
   arEnabled,
   setArEnabled,
-}: StreamControlsProps) {
+}: WebStreamControlsProps) {
   return (
     <>
       <div className="mt-4 flex items-center gap-4">

--- a/Frontend/src/pages/StudioPage/WebStreamControls.tsx
+++ b/Frontend/src/pages/StudioPage/WebStreamControls.tsx
@@ -1,0 +1,86 @@
+import { LuCamera, LuMonitor, LuImage, LuType, LuPencil, LuSparkles, LuPlay } from 'react-icons/lu';
+import ControlButton from './ControlButton';
+
+interface WebStreamControlsProps {
+  screenEnabled: boolean;
+  setScreenEnabled: (enabled: boolean) => void;
+  webcamEnabled: boolean;
+  setWebcamEnabled: (enabled: boolean) => void;
+  imageEnabled: boolean;
+  setImageEnabled: (enabled: boolean) => void;
+  textEnabled: boolean;
+  setTextEnabled: (enabled: boolean) => void;
+  drawEnabled: boolean;
+  setDrawEnabled: (enabled: boolean) => void;
+  arEnabled: boolean;
+  setArEnabled: (enabled: boolean) => void;
+}
+
+export default function WebStreamControls({
+  screenEnabled,
+  setScreenEnabled,
+  webcamEnabled,
+  setWebcamEnabled,
+  imageEnabled,
+  setImageEnabled,
+  textEnabled,
+  setTextEnabled,
+  drawEnabled,
+  setDrawEnabled,
+  arEnabled,
+  setArEnabled,
+}: StreamControlsProps) {
+  return (
+    <>
+      <div className="mt-4 flex items-center gap-4">
+        <div className="flex flex-wrap gap-2">
+          <ControlButton
+            icon={LuMonitor}
+            label="화면 공유"
+            isEnabled={screenEnabled}
+            onClick={() => setScreenEnabled(!screenEnabled)}
+          />
+
+          <ControlButton
+            icon={LuCamera}
+            label="웹캠"
+            isEnabled={webcamEnabled}
+            onClick={() => setWebcamEnabled(!webcamEnabled)}
+          />
+
+          <ControlButton
+            icon={LuImage}
+            label="이미지"
+            isEnabled={imageEnabled}
+            onClick={() => setImageEnabled(!imageEnabled)}
+          />
+
+          <ControlButton
+            icon={LuType}
+            label="텍스트"
+            isEnabled={textEnabled}
+            onClick={() => setTextEnabled(!textEnabled)}
+          />
+
+          <ControlButton
+            icon={LuPencil}
+            label="그리기"
+            isEnabled={drawEnabled}
+            onClick={() => setDrawEnabled(!drawEnabled)}
+          />
+
+          <ControlButton icon={LuSparkles} label="AR" isEnabled={arEnabled} onClick={() => setArEnabled(!arEnabled)} />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="mt-6 flex w-full items-center justify-center gap-2 rounded bg-lico-orange-2 px-4 py-2.5 font-bold text-lico-gray-5 transition-colors hover:bg-lico-orange-1"
+        aria-label="방송 시작하기"
+      >
+        <LuPlay className="-mt-0.5 h-5 w-5" aria-hidden="true" />
+        방송 시작하기
+      </button>
+    </>
+  );
+}

--- a/Frontend/src/pages/StudioPage/index.tsx
+++ b/Frontend/src/pages/StudioPage/index.tsx
@@ -19,7 +19,7 @@ export default function StudioPage() {
 
   return (
     <div className="flex h-screen">
-      <main className="min-w-96 flex-1 overflow-y-auto p-6" role="main">
+      <main className="scrollbar-hide min-w-96 flex-1 overflow-y-auto p-6" role="main">
         <h1 className="mb-4 font-bold text-2xl text-lico-gray-1">스튜디오</h1>
         <div className="mt-4">
           <VideoPlayer streamUrl="" />
@@ -84,7 +84,7 @@ export default function StudioPage() {
         </div>
       </main>
 
-      <aside className="min-w-96 overflow-y-auto bg-lico-gray-4 p-6" aria-label="방송 정보">
+      <aside className="scrollbar-hide min-w-96 overflow-y-auto bg-lico-gray-4 p-6" aria-label="방송 정보">
         <StreamInfo />
       </aside>
 

--- a/Frontend/src/pages/StudioPage/index.tsx
+++ b/Frontend/src/pages/StudioPage/index.tsx
@@ -1,19 +1,9 @@
-import VideoPlayer from '@/components/VideoPlayer';
-import {
-  LuSearch,
-  LuPlay,
-  LuCamera,
-  LuMonitor,
-  LuCopy,
-  LuEye,
-  LuEyeOff,
-  LuImage,
-  LuType,
-  LuPencil,
-  LuSparkles,
-} from 'react-icons/lu';
 import { useState } from 'react';
-import ChatWindow from '@/components/chat/ChatWindow';
+import VideoPlayer from '@components/VideoPlayer';
+import StreamSettings from '@pages/StudioPage/StreamSettings';
+import WebStreamControls from '@pages/StudioPage/WebStreamControls';
+import StreamInfo from '@pages/StudioPage/StreamInfo';
+import ChatWindow from '@components/chat/ChatWindow';
 
 type StreamType = 'OBS' | 'WebOBS';
 
@@ -27,21 +17,17 @@ export default function StudioPage() {
   const [drawEnabled, setDrawEnabled] = useState(false);
   const [arEnabled, setArEnabled] = useState(false);
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
-
   return (
     <div className="flex h-screen">
-      <div className="flex-1 p-6">
-        <div className="mb-4 font-bold text-2xl text-lico-gray-1">스튜디오</div>
+      <main className="min-w-96 flex-1 overflow-y-auto p-6" role="main">
+        <h1 className="mb-4 font-bold text-2xl text-lico-gray-1">스튜디오</h1>
         <div className="mt-4">
           <VideoPlayer streamUrl="" />
         </div>
 
         <div className="mt-4">
           <div className="flex justify-end">
-            <div className="inline-flex rounded-lg bg-lico-gray-4 p-1">
+            <div className="inline-flex rounded-lg bg-lico-gray-4 p-1" role="tablist">
               <button
                 type="button"
                 onClick={() => setStreamType('OBS')}
@@ -50,6 +36,9 @@ export default function StudioPage() {
                     ? 'bg-lico-orange-2 text-lico-gray-5'
                     : 'text-lico-gray-1 hover:text-lico-orange-2'
                 }`}
+                role="tab"
+                aria-selected={streamType === 'OBS'}
+                aria-controls="obs-panel"
               >
                 OBS
               </button>
@@ -61,6 +50,9 @@ export default function StudioPage() {
                     ? 'bg-lico-orange-2 text-lico-gray-5'
                     : 'text-lico-gray-1 hover:text-lico-orange-2'
                 }`}
+                role="tab"
+                aria-selected={streamType === 'WebOBS'}
+                aria-controls="webobs-panel"
               >
                 WebOBS
               </button>
@@ -68,203 +60,37 @@ export default function StudioPage() {
           </div>
 
           {streamType === 'OBS' ? (
-            <div className="mt-4 space-y-4">
-              <div>
-                <label className="mb-2 block font-bold text-sm text-lico-gray-1">스트림 URL</label>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    readOnly
-                    className="flex-1 rounded bg-lico-gray-4 p-2 font-medium text-sm text-lico-gray-1 outline-none"
-                    value="rtmp://stream.example.com/live"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => copyToClipboard('rtmp://stream.example.com/live')}
-                    className="flex items-center justify-center rounded bg-lico-gray-3 px-3 text-lico-gray-1 hover:bg-lico-gray-1 hover:text-lico-orange-2"
-                  >
-                    <LuCopy className="h-4 w-4" />
-                  </button>
-                </div>
-              </div>
-              <div>
-                <label className="mb-2 block font-bold text-sm text-lico-gray-1">스트림 키</label>
-                <div className="flex gap-2">
-                  <div className="relative flex-1">
-                    <input
-                      type={showStreamKey ? 'text' : 'password'}
-                      readOnly
-                      className="w-full rounded bg-lico-gray-4 p-2 font-medium text-sm text-lico-gray-1 outline-none"
-                      value="xxxx-xxxx-xxxx-xxxx"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowStreamKey(!showStreamKey)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-lico-gray-1 hover:text-lico-orange-2"
-                    >
-                      {showStreamKey ? <LuEyeOff className="h-4 w-4" /> : <LuEye className="h-4 w-4" />}
-                    </button>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => copyToClipboard('xxxx-xxxx-xxxx-xxxx')}
-                    className="flex items-center justify-center rounded bg-lico-gray-3 px-3 text-lico-gray-1 hover:bg-lico-gray-1 hover:text-lico-orange-2"
-                  >
-                    <LuCopy className="h-4 w-4" />
-                  </button>
-                </div>
-              </div>
+            <div id="obs-panel" role="tabpanel">
+              <StreamSettings showStreamKey={showStreamKey} setShowStreamKey={setShowStreamKey} />
             </div>
           ) : (
-            <>
-              <div className="mt-4 flex items-center gap-4">
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setScreenEnabled(!screenEnabled)}
-                    className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
-                      screenEnabled
-                        ? 'bg-lico-orange-2 text-lico-gray-5'
-                        : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
-                    }`}
-                  >
-                    <LuMonitor className="-mt-0.5 h-4 w-4" />
-                    화면 공유
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setWebcamEnabled(!webcamEnabled)}
-                    className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
-                      webcamEnabled
-                        ? 'bg-lico-orange-2 text-lico-gray-5'
-                        : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
-                    }`}
-                  >
-                    <LuCamera className="-mt-0.5 h-4 w-4" />
-                    웹캠
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setImageEnabled(!imageEnabled)}
-                    className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
-                      imageEnabled
-                        ? 'bg-lico-orange-2 text-lico-gray-5'
-                        : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
-                    }`}
-                  >
-                    <LuImage className="-mt-0.5 h-4 w-4" />
-                    이미지
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setTextEnabled(!textEnabled)}
-                    className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
-                      textEnabled
-                        ? 'bg-lico-orange-2 text-lico-gray-5'
-                        : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
-                    }`}
-                  >
-                    <LuType className="-mt-0.5 h-4 w-4" />
-                    텍스트
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setDrawEnabled(!drawEnabled)}
-                    className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
-                      drawEnabled
-                        ? 'bg-lico-orange-2 text-lico-gray-5'
-                        : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
-                    }`}
-                  >
-                    <LuPencil className="-mt-0.5 h-4 w-4" />
-                    그리기
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setArEnabled(!arEnabled)}
-                    className={`flex items-center gap-1.5 rounded px-2.5 py-1.5 font-medium text-sm transition-colors ${
-                      arEnabled
-                        ? 'bg-lico-orange-2 text-lico-gray-5'
-                        : 'bg-lico-gray-4 text-lico-gray-1 hover:text-lico-orange-2'
-                    }`}
-                  >
-                    <LuSparkles className="-mt-0.5 h-4 w-4" />
-                    AR
-                  </button>
-                </div>
-              </div>
-              <button
-                type="button"
-                className="mt-6 flex w-full items-center justify-center gap-2 rounded bg-lico-orange-2 px-4 py-2.5 font-bold text-lico-gray-5 transition-colors hover:bg-lico-orange-1"
-              >
-                <LuPlay className="-mt-0.5 h-5 w-5" />
-                방송 시작하기
-              </button>
-            </>
+            <div id="webobs-panel" role="tabpanel">
+              <WebStreamControls
+                screenEnabled={screenEnabled}
+                setScreenEnabled={setScreenEnabled}
+                webcamEnabled={webcamEnabled}
+                setWebcamEnabled={setWebcamEnabled}
+                imageEnabled={imageEnabled}
+                setImageEnabled={setImageEnabled}
+                textEnabled={textEnabled}
+                setTextEnabled={setTextEnabled}
+                drawEnabled={drawEnabled}
+                setDrawEnabled={setDrawEnabled}
+                arEnabled={arEnabled}
+                setArEnabled={setArEnabled}
+              />
+            </div>
           )}
         </div>
-      </div>
+      </main>
 
-      <div className="w-96 bg-lico-gray-4 p-6">
-        <form className="flex flex-col gap-6">
-          <div>
-            <label className="mb-2 block font-bold text-lico-gray-1">방송 제목</label>
-            <input
-              type="text"
-              className="w-full rounded bg-lico-gray-5 p-2 font-medium text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
-            />
-          </div>
+      <aside className="min-w-96 overflow-y-auto bg-lico-gray-4 p-6" aria-label="방송 정보">
+        <StreamInfo />
+      </aside>
 
-          <div>
-            <label className="mb-2 block font-bold text-lico-gray-1">방송 설명</label>
-            <textarea className="h-24 w-full resize-none overflow-y-auto rounded bg-lico-gray-5 p-2 font-medium text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2" />
-          </div>
-
-          <div>
-            <label className="mb-2 block font-bold text-lico-gray-1">카테고리</label>
-            <div className="relative">
-              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                <LuSearch className="h-4 w-4 text-lico-gray-2" />
-              </div>
-              <input
-                type="text"
-                className="w-full rounded bg-lico-gray-5 py-2 pl-9 pr-2 font-medium text-sm text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
-                placeholder="카테고리 검색"
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="mb-2 block font-bold text-lico-gray-1">
-              태그<span className="text-lico-gray-2"> (최대 5개)</span>
-            </label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                className="flex-1 rounded bg-lico-gray-5 p-2 font-medium text-sm text-lico-gray-1 outline-none focus:ring-2 focus:ring-lico-orange-2"
-                placeholder="태그 입력"
-              />
-              <button
-                type="button"
-                className="whitespace-nowrap rounded-md bg-lico-gray-3 px-3 py-2 font-medium text-sm text-lico-gray-1 hover:bg-lico-gray-1 hover:text-lico-orange-2"
-              >
-                추가
-              </button>
-            </div>
-          </div>
-
-          <button
-            type="submit"
-            className="flex items-center justify-center gap-2 rounded bg-lico-orange-2 px-4 py-2 font-bold text-lico-gray-5 transition-colors hover:bg-lico-orange-1"
-          >
-            업데이트
-          </button>
-        </form>
-      </div>
-
-      <div className="w-80 border-x border-lico-gray-3 bg-lico-gray-4">
+      <aside className="min-w-96 overflow-hidden border-x border-lico-gray-3 bg-lico-gray-4" aria-label="채팅">
         <ChatWindow />
-      </div>
+      </aside>
     </div>
   );
 }

--- a/Frontend/src/pages/StudioPage/index.tsx
+++ b/Frontend/src/pages/StudioPage/index.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import useLayoutStore from '@store/useLayoutStore';
 import VideoPlayer from '@components/VideoPlayer';
 import StreamSettings from '@pages/StudioPage/StreamSettings';
 import WebStreamControls from '@pages/StudioPage/WebStreamControls';
 import StreamInfo from '@pages/StudioPage/StreamInfo';
 import ChatWindow from '@components/chat/ChatWindow';
+import ChatOpenButton from '@components/common/Buttons/ChatOpenButton';
 
 type StreamType = 'OBS' | 'WebOBS';
 
@@ -16,6 +18,8 @@ export default function StudioPage() {
   const [textEnabled, setTextEnabled] = useState(false);
   const [drawEnabled, setDrawEnabled] = useState(false);
   const [arEnabled, setArEnabled] = useState(false);
+
+  const { chatState, toggleChat } = useLayoutStore();
 
   return (
     <div className="flex h-screen">
@@ -88,9 +92,12 @@ export default function StudioPage() {
         <StreamInfo />
       </aside>
 
-      <aside className="min-w-96 overflow-hidden border-x border-lico-gray-3 bg-lico-gray-4" aria-label="채팅">
-        <ChatWindow />
-      </aside>
+      {chatState === 'expanded' && (
+        <aside className="min-w-96 overflow-hidden border-x border-lico-gray-3 bg-lico-gray-4" aria-label="채팅">
+          <ChatWindow />
+        </aside>
+      )}
+      {chatState === 'hidden' && <ChatOpenButton className="text-lico-gray-2" onClick={toggleChat} />}
     </div>
   );
 }

--- a/Frontend/src/store/useFollowStore.ts
+++ b/Frontend/src/store/useFollowStore.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-interface State {
+interface FollowState {
   followingChannels: string[];
   followChannel: (channelId: string) => void;
   unfollowChannel: (channelId: string) => void;
 }
 
-const useStore = create<State>()(
+const useFollowStore = create<FollowState>()(
   persist(
     set => ({
       followingChannels: [],
@@ -23,7 +23,7 @@ const useStore = create<State>()(
       },
     }),
     {
-      name: 'app-storage',
+      name: 'follow-storage',
       partialize: state => ({
         followingChannels: state.followingChannels || [],
       }),
@@ -31,4 +31,4 @@ const useStore = create<State>()(
   ),
 );
 
-export default useStore;
+export default useFollowStore;

--- a/Frontend/src/utils/chatUtils.ts
+++ b/Frontend/src/utils/chatUtils.ts
@@ -1,4 +1,4 @@
-import { TAILWIND_USER_COLORS } from './constants';
+import { TAILWIND_USER_COLORS } from '@constants/chat/color';
 
 // 텍스트의 각 문자 코드 합을 기반으로 일관된 테일윈드 스타일 색상을 반환하는 함수
 export const getConsistentTextColor = (text: string): (typeof TAILWIND_USER_COLORS)[number] =>

--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -23,9 +23,9 @@ export default {
       screens: {
         'cards-4': '1328px', // 4x320px + 3x16px = 1328px
         'cards-5': '1664px', // 5x320px + 4x16px = 1664px
-        'cards-6': '2000px' // 6x320px + 5x16px = 2000px
+        'cards-6': '2000px', // 6x320px + 5x16px = 2000px
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar-hide')],
 };


### PR DESCRIPTION
## 📝 PR 설명
- 비디오플레이어, 스튜디오 페이지 컴포넌트 간단하게 분리했습니다.
- 스크롤바 없애기를 테일윈드 플러그인을 설치해 간소화 했습니다.
- 스튜디오 페이지 채팅창도 접기 연결했습니다.
- `setUseChannel`하는 과정에서 조건 비교를 잘못하고 있는 버그를 수정했습니다. [링크](https://far-woodwind-e60.notion.site/live-id-url-08638f25e9464fdf98827bfcbde802f5?pvs=4)
- 기존 useStore.ts의 이름을 useFollowStore.ts로 변경했습니다.
- 하단 이동 버튼이 입력창 크기에 따라 위치가 변하도록 수정했습니다.
- 기존 chat 컴포넌트 내부에 있던 util.ts 과 constant.ts를 분리했습니다.

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->


## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->
![스크롤개선1](https://github.com/user-attachments/assets/00a4bad5-0333-4331-aa52-912b5c6ea0e2)

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->


## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->


