### PR TITLE
[Feature] 라이브 방송 시작,종료 알림 API 및 채널ID 획득 API 추가(서버용)

### DIFF
--- a/Backend/src/lives/dto/live.dto.ts
+++ b/Backend/src/lives/dto/live.dto.ts
@@ -4,6 +4,6 @@ export class LiveDto {
   readonly startedAt: Date;
   readonly usersNickname: string;
   readonly usersProfileImage: string;
-  readonly categoriesId: number;
-  readonly categoriesName: string;
+  readonly categoriesId: number | null;
+  readonly categoriesName: string | null;
 }

--- a/Backend/src/lives/dto/lives.dto.ts
+++ b/Backend/src/lives/dto/lives.dto.ts
@@ -3,6 +3,6 @@ export class LivesDto {
   readonly livesName: string;
   readonly usersNickname: string;
   readonly usersProfileImage: string;
-  readonly categoriesId: number;
-  readonly categoriesName: string;
+  readonly categoriesId: number | null;
+  readonly categoriesName: string | null;
 }

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -13,7 +13,6 @@ import {
 } from 'typeorm';
 import { LivesDto } from '../dto/lives.dto';
 import { LiveDto } from '../dto/live.dto';
-import { UpdateLiveDto } from '../dto/update.live.dto';
 
 @Entity('lives')
 export class LiveEntity {
@@ -59,8 +58,8 @@ export class LiveEntity {
 
   toLivesDto(): LivesDto {
     return {
-      categoriesId: this.category.id,
-      categoriesName: this.category.name,
+      categoriesId: this.category?.id,
+      categoriesName: this.category?.name,
       livesName: this.name,
       channelId: this.channelId,
       usersNickname: this.user.nickname,
@@ -70,21 +69,13 @@ export class LiveEntity {
 
   toLiveDto(): LiveDto {
     return {
-      categoriesId: this.category.id,
-      categoriesName: this.category.name,
+      categoriesId: this.category?.id,
+      categoriesName: this.category?.name,
       livesName: this.name,
       livesDescription: this.description,
       startedAt: this.startedAt,
       usersNickname: this.user.nickname,
       usersProfileImage: this.user.profileImage,
-    };
-  }
-
-  toUpdateLiveDto(): UpdateLiveDto {
-    return {
-      categoriesId: this.category.id,
-      name: this.name,
-      description: this.description,
     };
   }
 }

--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -3,6 +3,7 @@ import { LivesService } from './lives.service';
 import { LivesDto } from './dto/lives.dto';
 import { LiveDto } from './dto/live.dto';
 import { UpdateLiveDto } from './dto/update.live.dto';
+import { UUID } from 'crypto';
 
 @Controller('lives')
 export class LivesController {
@@ -14,12 +15,17 @@ export class LivesController {
   }
 
   @Get('/:channelId')
-  async getLive(@Param('channelId') channelId: string): Promise<LiveDto> {
+  async getLive(@Param('channelId') channelId: UUID): Promise<LiveDto> {
     return await this.livesService.readLive(channelId);
   }
 
   @Patch('/:channelId')
-  async setLive(@Param('channelId') channelId: string, @Body(ValidationPipe) updateLiveDto: UpdateLiveDto) {
+  async setLive(@Param('channelId') channelId: UUID, @Body(ValidationPipe) updateLiveDto: UpdateLiveDto) {
     await this.livesService.updateLive({ channelId, updateLiveDto });
+  }
+
+  @Get('/channel-id/:streamingKey')
+  async getChannelId(@Param('streamingKey') streamingKey: UUID) {
+    return await this.livesService.readChannelId(streamingKey);
   }
 }

--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpCode, Param, Patch, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, ValidationPipe } from '@nestjs/common';
 import { LivesService } from './lives.service';
 import { LivesDto } from './dto/lives.dto';
 import { LiveDto } from './dto/live.dto';
@@ -20,6 +20,7 @@ export class LivesController {
   }
 
   @Patch('/:channelId')
+  @HttpCode(204)
   async setLive(@Param('channelId') channelId: UUID, @Body(ValidationPipe) updateLiveDto: UpdateLiveDto) {
     await this.livesService.updateLive({ channelId, updateLiveDto });
   }
@@ -27,5 +28,17 @@ export class LivesController {
   @Get('/channel-id/:streamingKey')
   async getChannelId(@Param('streamingKey') streamingKey: UUID) {
     return await this.livesService.readChannelId(streamingKey);
+  }
+
+  @Post('/onair/:streamingKey')
+  @HttpCode(204)
+  async startLive(@Param('streamingKey') streamingKey: UUID) {
+    await this.livesService.startLive(streamingKey);
+  }
+
+  @Delete('/onair/:streamingKey')
+  @HttpCode(202)
+  async endLive(@Param('streamingKey') streamingKey: UUID) {
+    this.livesService.endLive(streamingKey);
   }
 }

--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -31,9 +31,9 @@ export class LivesController {
   }
 
   @Post('/onair/:streamingKey')
-  @HttpCode(204)
   async startLive(@Param('streamingKey') streamingKey: UUID) {
     await this.livesService.startLive(streamingKey);
+    return 0;
   }
 
   @Delete('/onair/:streamingKey')

--- a/Backend/src/lives/lives.service.spec.ts
+++ b/Backend/src/lives/lives.service.spec.ts
@@ -65,6 +65,31 @@ describe('LivesService', () => {
         profileImage: 'https://example.com/jane-profile.jpg',
       },
     }),
+    createMockLiveEntity({
+      id: 3,
+      categoriesId: 3,
+      category: {
+        id: 3,
+        name: 'Talk Show',
+        image: 'https://example.com/talkshow.jpg',
+        createdAt: new Date('2024-11-06T14:00:00Z'),
+        updatedAt: new Date('2024-11-06T14:00:00Z'),
+      },
+      channelId: 'ghi789',
+      name: 'Evening Talk Show',
+      description: 'Discussing trending topics.',
+      streamingKey: 'key789',
+      onAir: false, // `onAir` 값이 false로 설정됨
+      startedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      user: {
+        id: 3,
+        nickname: 'HostName',
+        profileImage: 'https://example.com/host-profile.jpg',
+      },
+    }),
   ];
 
   const mockLivesRepository = {
@@ -93,14 +118,14 @@ describe('LivesService', () => {
   describe('readLives', () => {
     it('라이브 서비스가 라이브 목록을 반환합니다.', async () => {
       // Given
-      mockLivesRepository.find.mockResolvedValue(mockLives);
+      mockLivesRepository.find.mockResolvedValue(mockLives.filter(entity => entity.onAir));
 
       // When
       const lives = await service.readLives();
 
       // Then
       expect(repository.find).toHaveBeenCalledTimes(1);
-      expect(repository.find).toHaveBeenCalledWith({ relations: ['category'] });
+      expect(repository.find).toHaveBeenCalledWith({ relations: ['category', 'user'], where: { onAir: true } });
       expect(lives).toEqual([
         {
           categoriesId: 1,

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -28,7 +28,7 @@ export class LivesService {
 
   async readChannelId(streamingKey: UUID) {
     const live = await this.livesRepository.findOne({ where: { streamingKey } });
-    return live.channelId;
+    return { channelId: live.channelId };
   }
 
   async startLive(streamingKey: UUID) {

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -10,12 +10,11 @@ export class LivesService {
   constructor(@InjectRepository(LiveEntity) private livesRepository: Repository<LiveEntity>) {}
 
   async readLives(): Promise<LivesDto[]> {
-    const lives = await this.livesRepository.find({ relations: ['category', 'user'] });
+    const lives = await this.livesRepository.find({ relations: ['category', 'user'], where: { onAir: true } });
     return lives.map(entity => entity.toLivesDto());
   }
 
   async readLive(channelId: string): Promise<LiveDto> {
-    // TODO 라이브 테이블에 채널아이디로 인덱스 추가
     const live = await this.livesRepository.findOne({ relations: ['category', 'user'], where: { channelId } });
     return live.toLiveDto();
   }

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { LivesDto } from './dto/lives.dto';
 import { LiveDto } from './dto/live.dto';
+import { UUID } from 'crypto';
 
 @Injectable()
 export class LivesService {
@@ -22,5 +23,10 @@ export class LivesService {
   async updateLive({ channelId, updateLiveDto }) {
     // TODO 요청자와 채널 소유자 일치여부 체크(로그인 기능 구현 후)
     await this.livesRepository.update({ channelId }, updateLiveDto);
+  }
+
+  async readChannelId(streamingKey: UUID) {
+    const live = await this.livesRepository.findOne({ where: { streamingKey } });
+    return live.channelId;
   }
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
ingest 서버, encoding 서버에서 방송 시작, 종료 시 정보 갱신을 위해 필요한 API를 추가하였습니다.

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

- GET /lives/channel-id/{streamingKey} : 채널 아이디 조회 API
- POST /lives/onair/{streamingKey} : 방송 시작 요청 - 방송 상태와 방송 시작 시간을 갱신합니다.
- DELETE /lives/onair/{streamingKey} : 방송 종료 요청 - 방송 상태를 갱신합니다.
- #143 수정
- #142 수정
## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #150 #151 #143 #142 #149 

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->

- [ ] 테스트 추가
