### PR TITLE
[Fix] srs webhook 사양에 맞게 방송 시작 api 정상 응답 200으로 변경

### DIFF
--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -31,6 +31,7 @@ export class LivesController {
   }
 
   @Post('/onair/:streamingKey')
+  @HttpCode(200)
   async startLive(@Param('streamingKey') streamingKey: UUID) {
     await this.livesService.startLive(streamingKey);
     return 0;


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
방송 시작 API의 응답코드를 200으로 변경
