### PR TITLE
[Fix]: live_id 값이 null이 되는 거 수정

### DIFF
--- a/Backend/src/auth/strategies/github.strategy.ts
+++ b/Backend/src/auth/strategies/github.strategy.ts
@@ -25,9 +25,6 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
     done: Function,
   ) {
     try {
-      console.log('Access Token:', accessToken);
-      console.log('Profile:', profile);
-
       const { id: oauthUid, username, displayName, photos } = profile;
       const jwt = await this.authService.validateOAuthLogin(
         oauthUid,
@@ -41,7 +38,6 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
       const user = { jwt };
       done(null, user);
     } catch (error) {
-      console.error('Error in GitHub validate:', error);
       done(error, false);
     }
   }

--- a/Backend/src/users/users.service.ts
+++ b/Backend/src/users/users.service.ts
@@ -49,7 +49,7 @@ export class UsersService {
       // UserEntity 생성
       const newUser = manager.create(UserEntity, {
         ...createUserDto,
-        livesId: savedLive.id, // LiveEntity의 id 사용
+        live: savedLive, // 올바른 관계 필드에 값 할당
       });
       const savedUser = await manager.save(newUser);
 


### PR DESCRIPTION
## 📝 PR 설명
`lico.digital/live` 랜더링이 되지 않아서 log를 확인해보니,
```[Nest] 45393  - 11/12/2024, 1:53:55 AM   ERROR [ExceptionsHandler] Cannot read properties of null (reading 'nickname')
TypeError: Cannot read properties of null (reading 'nickname')
    at LiveEntity.toLivesDto (/root/lico/Backend/dist/lives/entity/live.entity.js:23:38)
    at /root/lico/Backend/dist/lives/lives.service.js:26:43
    at Array.map (<anonymous>)
    at LivesService.readLives (/root/lico/Backend/dist/lives/lives.service.js:26:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async LivesController.getLives (/root/lico/Backend/dist/lives/lives.controller.js:24:16)
```
- 원인을 찾아보니, user 의 lives_id 가 null 로 되어 있었습니다. 그래서수정을 했습니다.

## ✅ 주요 변경 사항
- [x] UsersService.createUser 메서드에서 UserEntity를 생성할 때, live 관계 필드에 savedLive를 할당

### 이전 liveId를 넣고 있음
```
// UsersService.createUser 메서드 
const newUser = manager.create(UserEntity, {
  ...createUserDto,
  livesId: savedLive.id, // 잘못된 필드에 값 할당
});
```

### 변경 후: live 엔티티 넣음
```
// UsersService.createUser 메서드
const newUser = manager.create(UserEntity, {
  ...createUserDto,
  live: savedLive, // 올바른 관계 필드에 값 할당
});
```

### lico_dev 의 잘못된 데이터 모두 삭제
- 현재 더미데이터 30개만 존재
- 이후 회원가입 시 38번 부터 자동으로 증가함


## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/239782da-aace-4bc0-a858-eb911d72d71f)
- live_id 에 값이 잘 들어감

## 🔗 관련 이슈
## 🛠️ 추가 작업 (선택)
