### PR TITLE
[Feature] useHls 기능 추가, 로딩 컴포넌트 구현, 방송 시간 계산 컴포넌트 추가

### DIFF
--- a/Frontend/src/components/LiveInfo/StreamingTimer.tsx
+++ b/Frontend/src/components/LiveInfo/StreamingTimer.tsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react';
+
+interface StreamingTimerProps {
+  startAt: string | Date;
+}
+
+function StreamingTimer({ startAt }: StreamingTimerProps) {
+  const [duration, setDuration] = useState('00:00:00');
+
+  useEffect(() => {
+    const updateDuration = () => {
+      const startTime = new Date(startAt).getTime();
+      const diff = Math.floor((Date.now() - startTime) / 1000);
+      const h = Math.floor(diff / 3600)
+        .toString()
+        .padStart(2, '0');
+      const m = Math.floor((diff % 3600) / 60)
+        .toString()
+        .padStart(2, '0');
+      const s = Math.floor(diff % 60)
+        .toString()
+        .padStart(2, '0');
+      setDuration(`${h}:${m}:${s}`);
+    };
+
+    updateDuration();
+    const interval = setInterval(updateDuration, 1000);
+    return () => clearInterval(interval);
+  }, [startAt]);
+
+  return <div className="text-xs text-lico-gray-2">{duration} 스트리밍 중</div>;
+}
+
+export default StreamingTimer;

--- a/Frontend/src/components/LiveInfo/index.tsx
+++ b/Frontend/src/components/LiveInfo/index.tsx
@@ -4,6 +4,7 @@ import FollowButton from '@components/common/Buttons/FollowButton';
 import { useState } from 'react';
 import { useChannel } from '@contexts/ChannelContext';
 import { formatNumber } from '@utils/format';
+import StreamingTimer from '@components/LiveInfo/StreamingTimer';
 
 interface LiveInfoProps {
   channelId: string;
@@ -19,12 +20,12 @@ export default function LiveInfo({ channelId }: LiveInfoProps) {
     <div className="w-full bg-lico-gray-4 p-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <div className="rounded-full bg-white p-2">
+          <div className="rounded-full bg-white">
             {!imageError ? (
               <img
                 src={currentChannel.profileImgUrl}
                 alt={currentChannel.streamerName}
-                className="h-6 w-6 rounded-full"
+                className="h-12 w-12 rounded-full"
                 onError={() => setImageError(true)}
               />
             ) : (
@@ -34,11 +35,12 @@ export default function LiveInfo({ channelId }: LiveInfoProps) {
           <div>
             <div className="font-bold text-base text-lico-orange-2">{currentChannel.streamerName}</div>
             <div className="font-medium text-sm text-lico-gray-2">{formatNumber(currentChannel.viewers)}명 시청중</div>
+            <StreamingTimer startAt={currentChannel.createdAt} />
           </div>
         </div>
         <FollowButton channelId={channelId} />
       </div>
-      <div className="mt-2 font-medium text-lico-gray-1">{currentChannel.title}</div>
+      <div className="mt-2 font-medium text-xl text-lico-gray-1">{currentChannel.title}</div>
       <div className="mt-2 flex items-center gap-2">
         <CategoryBadge
           category={currentChannel.category.name}

--- a/Frontend/src/components/VideoPlayer/LoadingSpinner.tsx
+++ b/Frontend/src/components/VideoPlayer/LoadingSpinner.tsx
@@ -1,0 +1,22 @@
+import { PiOrange } from 'react-icons/pi';
+
+interface LoadingSpinnerProps {
+  size?: number;
+}
+
+export default function LoadingSpinner({ size = 64 }: LoadingSpinnerProps) {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="relative h-16 w-16">
+        <div className="absolute text-lico-orange-2">
+          <PiOrange size={size} />
+        </div>
+        <div className="absolute inset-0 overflow-hidden">
+          <div className="animate-fill-orange text-lico-orange-1">
+            <PiOrange size={size} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -9,7 +9,7 @@ interface VideoPlayerProps {
 }
 
 export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
-  const [isPlaying, setIsPlaying] = useState(true);
+  const [isPlaying, setIsPlaying] = useState(false);
   const [volume, setVolume] = useState(1);
   const [isMuted, setIsMuted] = useState(true);
   const [isFullScreen, setIsFullScreen] = useState(false);
@@ -119,7 +119,7 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
-      <video ref={videoRef} className="h-full w-full bg-black" muted autoPlay playsInline>
+      <video ref={videoRef} className="h-full w-full bg-black" onPlay={togglePlay} muted autoPlay playsInline>
         <track kind="captions" src="" />
       </video>
       {isBuffering && (

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -8,9 +8,9 @@ interface VideoPlayerProps {
 }
 
 export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(true);
   const [volume, setVolume] = useState(1);
-  const [isMuted, setIsMuted] = useState(false);
+  const [isMuted, setIsMuted] = useState(true);
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [showCursor, setShowCursor] = useState(true);
@@ -41,17 +41,19 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
   };
 
   const handleVolumeChange = (newVolume: number) => {
-    setVolume(newVolume);
     if (videoRef.current) {
+      videoRef.current.muted = false;
       videoRef.current.volume = newVolume;
     }
     setIsMuted(newVolume === 0);
+    setVolume(newVolume || 1);
   };
 
   const toggleMute = () => {
     if (videoRef.current) {
+      videoRef.current.muted = false;
       if (isMuted) {
-        videoRef.current.volume = volume || 1;
+        videoRef.current.volume = volume;
         setIsMuted(false);
       } else {
         videoRef.current.volume = 0;
@@ -134,9 +136,8 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
-      <video ref={videoRef} className="h-full w-full bg-black" autoPlay playsInline>
+      <video ref={videoRef} className="h-full w-full bg-black" muted autoPlay playsInline>
         <track kind="captions" src="" />
-        브라우저가 비디오 재생을 지원하지 않습니다.
       </video>
       {isBuffering && (
         <div className="absolute inset-0 z-10 flex items-center justify-center">

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -138,6 +138,11 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
         <track kind="captions" src="" />
         브라우저가 비디오 재생을 지원하지 않습니다.
       </video>
+      {isBuffering && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      )}
 
       <Controls
         isPlaying={isPlaying}

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -97,17 +97,6 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
   };
 
   useEffect(() => {
-    const handleFullScreenChange = () => {
-      setIsFullScreen(!!document.fullscreenElement);
-    };
-
-    document.addEventListener('fullscreenchange', handleFullScreenChange);
-    return () => {
-      document.removeEventListener('fullscreenchange', handleFullScreenChange);
-    };
-  }, []);
-
-  useEffect(() => {
     return () => {
       if (controlsTimeoutRef.current) {
         clearTimeout(controlsTimeoutRef.current);

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import useLayoutStore from '@store/useLayoutStore';
-import useHls from '@hooks/useHls.ts';
+import useHls from '@hooks/useHls';
+import LoadingSpinner from '@components/VideoPlayer/LoadingSpinner';
 import Controls from './Control/index';
 
 interface VideoPlayerProps {
@@ -14,20 +15,13 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [showCursor, setShowCursor] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
   const { videoPlayerState, toggleVideoPlayer } = useLayoutStore();
+
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsTimeoutRef = useRef<NodeJS.Timeout>();
 
-  // HLS 초기화
-  useHls(streamUrl, videoRef, {
-    debug: false,
-    enableWorker: true,
-    lowLatencyMode: true,
-    onError: err => setError(err),
-  });
+  const { isBuffering, error } = useHls(streamUrl, videoRef);
 
   const togglePlay = () => {
     if (videoRef.current) {

--- a/Frontend/src/components/VideoPlayer/index.tsx
+++ b/Frontend/src/components/VideoPlayer/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import useLayoutStore from '@store/useLayoutStore';
+import useHls from '@hooks/useHls.ts';
 import Controls from './Control/index';
-import { useHls } from './useHls';
 
 interface VideoPlayerProps {
   streamUrl: string;
@@ -26,7 +26,7 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
     debug: false,
     enableWorker: true,
     lowLatencyMode: true,
-    onError: (err) => setError(err),
+    onError: err => setError(err),
   });
 
   const togglePlay = () => {
@@ -134,12 +134,7 @@ export default function VideoPlayer({ streamUrl }: VideoPlayerProps) {
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
-      <video
-        ref={videoRef}
-        className="h-full w-full bg-black"
-        autoPlay
-        playsInline
-      >
+      <video ref={videoRef} className="h-full w-full bg-black" autoPlay playsInline>
         <track kind="captions" src="" />
         브라우저가 비디오 재생을 지원하지 않습니다.
       </video>

--- a/Frontend/src/hooks/useHls.ts
+++ b/Frontend/src/hooks/useHls.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import Hls from 'hls.js';
 
 interface HlsOptions {
@@ -8,16 +8,17 @@ interface HlsOptions {
   onError?: (error: Error) => void;
 }
 
-export const useHls = (
+const useHls = (
   streamUrl: string | undefined,
   videoRef: React.RefObject<HTMLVideoElement>,
   options: HlsOptions = {},
 ) => {
   useEffect(() => {
     let hls: Hls | null = null;
+    const videoElement = videoRef.current;
 
     const initHls = () => {
-      if (!videoRef.current || !streamUrl) return;
+      if (!videoElement || !streamUrl) return;
 
       if (Hls.isSupported()) {
         hls = new Hls({
@@ -27,7 +28,7 @@ export const useHls = (
         });
 
         hls.loadSource(streamUrl);
-        hls.attachMedia(videoRef.current);
+        hls.attachMedia(videoElement);
 
         hls.on(Hls.Events.ERROR, (_event, data) => {
           if (data.fatal) {
@@ -47,8 +48,8 @@ export const useHls = (
             }
           }
         });
-      } else if (videoRef.current.canPlayType('application/vnd.apple.mpegurl')) {
-        videoRef.current.src = streamUrl;
+      } else if (videoElement.canPlayType('application/vnd.apple.mpegurl')) {
+        videoElement.src = streamUrl;
       } else {
         options.onError?.(new Error('HLS is not supported in this browser'));
       }
@@ -61,5 +62,7 @@ export const useHls = (
         hls.destroy();
       }
     };
-  }, [streamUrl, options.debug, options.enableWorker, options.lowLatencyMode]);
+  }, [streamUrl, videoRef, options]);
 };
+
+export default useHls;

--- a/Frontend/src/hooks/useHls.ts
+++ b/Frontend/src/hooks/useHls.ts
@@ -1,68 +1,113 @@
-import React, { useEffect } from 'react';
-import Hls from 'hls.js';
+import React, { useEffect, useState } from 'react';
+import Hls, { LevelSwitchedData } from 'hls.js';
 
-interface HlsOptions {
-  debug?: boolean;
-  enableWorker?: boolean;
-  lowLatencyMode?: boolean;
-  onError?: (error: Error) => void;
+interface Quality {
+  level: number;
+  height: number;
+  width: number;
+  bitrate: number;
 }
 
-const useHls = (
-  streamUrl: string | undefined,
-  videoRef: React.RefObject<HTMLVideoElement>,
-  options: HlsOptions = {},
-) => {
+const useHls = (streamUrl: string | undefined, videoRef: React.RefObject<HTMLVideoElement>) => {
+  const [isBuffering, setIsBuffering] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [currentQuality, setCurrentQuality] = useState<number>(-1);
+  const [qualities, setQualities] = useState<Quality[]>([]);
+  const [hls, setHls] = useState<Hls | null>(null);
+
   useEffect(() => {
-    let hls: Hls | null = null;
+    let hlsInstance: Hls | null = null;
     const videoElement = videoRef.current;
+
+    const handleBuffering = (buffering: boolean) => {
+      setIsBuffering(buffering);
+    };
+
+    const setupVideoListeners = () => {
+      if (!videoElement) return;
+
+      videoElement.addEventListener('waiting', () => handleBuffering(true));
+      videoElement.addEventListener('playing', () => handleBuffering(false));
+    };
+
+    const removeVideoListeners = () => {
+      if (!videoElement) return;
+
+      videoElement.removeEventListener('waiting', () => handleBuffering(true));
+      videoElement.removeEventListener('playing', () => handleBuffering(false));
+    };
 
     const initHls = () => {
       if (!videoElement || !streamUrl) return;
 
+      setError(null);
+
       if (Hls.isSupported()) {
-        hls = new Hls({
-          debug: options.debug ?? false,
-          enableWorker: options.enableWorker ?? true,
-          lowLatencyMode: options.lowLatencyMode ?? true,
+        hlsInstance = new Hls();
+        setHls(hlsInstance);
+
+        hlsInstance.loadSource(streamUrl);
+        hlsInstance.attachMedia(videoElement);
+
+        hlsInstance.on(Hls.Events.MANIFEST_PARSED, (_, data) => {
+          const availableQualities = data.levels.map((level, index) => ({
+            level: index,
+            height: level.height,
+            width: level.width,
+            bitrate: level.bitrate,
+          }));
+          setQualities(availableQualities);
         });
 
-        hls.loadSource(streamUrl);
-        hls.attachMedia(videoElement);
+        hlsInstance.on(Hls.Events.LEVEL_SWITCHED, (_, data: LevelSwitchedData) => {
+          setCurrentQuality(data.level);
+        });
 
-        hls.on(Hls.Events.ERROR, (_event, data) => {
+        hlsInstance.on(Hls.Events.ERROR, (_event, data) => {
           if (data.fatal) {
             switch (data.type) {
               case Hls.ErrorTypes.NETWORK_ERROR:
-                hls?.startLoad();
-                options.onError?.(new Error('Network error occurred'));
+                hlsInstance?.startLoad();
+                setError(new Error('Network error occurred'));
                 break;
               case Hls.ErrorTypes.MEDIA_ERROR:
-                hls?.recoverMediaError();
-                options.onError?.(new Error('Media error occurred'));
+                hlsInstance?.recoverMediaError();
+                setError(new Error('Media error occurred'));
                 break;
               default:
-                hls?.destroy();
-                options.onError?.(new Error('Fatal error occurred'));
+                hlsInstance?.destroy();
+                setError(new Error('Fatal error occurred'));
                 break;
             }
           }
         });
+
+        setupVideoListeners();
       } else if (videoElement.canPlayType('application/vnd.apple.mpegurl')) {
         videoElement.src = streamUrl;
+        setupVideoListeners();
       } else {
-        options.onError?.(new Error('HLS is not supported in this browser'));
+        setError(new Error('HLS is not supported in this browser'));
       }
     };
 
     initHls();
 
     return () => {
-      if (hls) {
-        hls.destroy();
+      if (hlsInstance) {
+        hlsInstance.destroy();
       }
+      removeVideoListeners();
     };
-  }, [streamUrl, videoRef, options]);
+  }, [streamUrl, videoRef]);
+
+  const setQuality = (level: number) => {
+    if (hls) {
+      hls.currentLevel = level;
+    }
+  };
+
+  return { isBuffering, error, qualities, currentQuality, setQuality };
 };
 
 export default useHls;

--- a/Frontend/src/pages/LivePage/index.tsx
+++ b/Frontend/src/pages/LivePage/index.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import LoadingSpinner from '@components/VideoPlayer/LoadingSpinner.tsx';
 import VideoPlayer from '@/components/VideoPlayer';
 import LiveInfo from '@/components/LiveInfo';
 import StreamerInfo from '@/components/LiveInfo/StreamerInfo';
@@ -12,10 +13,8 @@ import { useLiveDetail } from '@/hooks/useLive';
 
 export default function LivePage() {
   const { id } = useParams<{ id: string }>();
-
   const { currentChannel, setCurrentChannel } = useChannel();
   const { chatState, videoPlayerState, toggleChat, handleBreakpoint } = useLayoutStore();
-
   const { data: liveDetail, isLoading, error } = useLiveDetail(id!);
 
   const isLarge = useMediaQuery('(min-width: 1200px)');
@@ -39,7 +38,7 @@ export default function LivePage() {
   }, [liveDetail, currentChannel, id, setCurrentChannel]);
 
   if (!id) return <div>잘못된 접근입니다.</div>;
-  if (isLoading) return <div>로딩 중...</div>;
+  if (isLoading) return <LoadingSpinner />;
   if (error) return <div>에러가 발생했습니다.</div>;
   if (!liveDetail) return <div>존재하지 않는 채널입니다.</div>;
 
@@ -66,10 +65,8 @@ export default function LivePage() {
   return (
     <div className="flex h-screen">
       <div className="flex-1">
-        <div className="scrollbar-hide flex h-full flex-col overflow-y-auto">
-
+        <div className="flex h-full flex-col overflow-y-auto scrollbar-hide">
           <VideoPlayer streamUrl="https://objectstorage.ap-chuncheon-1.oraclecloud.com/n/axroqqceafgq/b/lico/o/SK1234567891.m3u8" />
-
           <LiveInfo channelId={id} />
           <StreamerInfo />
         </div>

--- a/Frontend/src/pages/LivePage/index.tsx
+++ b/Frontend/src/pages/LivePage/index.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import LoadingSpinner from '@components/VideoPlayer/LoadingSpinner.tsx';
 import VideoPlayer from '@/components/VideoPlayer';
 import LiveInfo from '@/components/LiveInfo';

--- a/Frontend/src/pages/StudioPage/index.tsx
+++ b/Frontend/src/pages/StudioPage/index.tsx
@@ -23,9 +23,9 @@ export default function StudioPage() {
 
   return (
     <div className="flex h-screen">
-      <main className="scrollbar-hide min-w-96 flex-1 overflow-y-auto p-6" role="main">
+      <main className="min-w-96 flex-1 overflow-y-auto p-6 scrollbar-hide" role="main">
         <h1 className="mb-4 font-bold text-2xl text-lico-gray-1">스튜디오</h1>
-        <div className="mt-4">
+        <div className="mt-4 h-3/5">
           <VideoPlayer streamUrl="" />
         </div>
 
@@ -88,7 +88,7 @@ export default function StudioPage() {
         </div>
       </main>
 
-      <aside className="scrollbar-hide min-w-96 overflow-y-auto bg-lico-gray-4 p-6" aria-label="방송 정보">
+      <aside className="min-w-96 overflow-y-auto bg-lico-gray-4 p-6 scrollbar-hide" aria-label="방송 정보">
         <StreamInfo />
       </aside>
 

--- a/Frontend/src/styles/index.css
+++ b/Frontend/src/styles/index.css
@@ -38,3 +38,16 @@ input[type='range']::-ms-thumb {
   width: 0;
   height: 0;
 }
+
+@keyframes fillOrange {
+  0% {
+    clip-path: inset(100% 0 0 0);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+.animate-fill-orange {
+  animation: fillOrange 0.5s ease-in-out infinite;
+}


### PR DESCRIPTION
## 📝 PR 설명
- 비디오 플레이어와 관련된 useHls 훅 작업했습니다.
  - 버퍼링 추가했습니다.
  - 화질 조정 기능을 위한 함수 구현 했습니다.
- 비디오 플레이어 버퍼링 시 사용할 LoadingSpinner 컴포넌트 작업했습니다.
  - 비디오 플레이어 버퍼링 시 적용했습니다.
  - LivePage 로딩시 적용했습니다.
- LivePage 방송 시간 추가했습니다. 

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

![image](https://github.com/user-attachments/assets/94760fe8-8f07-4430-9325-430d4ce5cc44)

```js
hlsInstance.on(Hls.Events.MANIFEST_PARSED, (_, data) => {
          const availableQualities = data.levels.map((level, index) => ({
            level: index,
            height: level.height,
            width: level.width,
            bitrate: level.bitrate,
          }));
          setQualities(availableQualities);
        });
```

샘플 m3u8 파일을 받았을 때, data를 변환한 결과입니다. 
level이 0이 가장 저화질, 높아질수록 고화질을 뜻합니다.
level : -1 은 '자동'을 뜻합니다.
여러 화질/해상도 버전의 정보를 포함하고 있는 Master Manifest을 따라 자동으로 화질을 설정하게 됩니다.

```
//Master Manifest
#EXTM3U
#EXT-X-VERSION:3

# 저화질 스트림 (360p)
#EXT-X-STREAM-INF:BANDWIDTH=800000,RESOLUTION=640x360
stream_360p.m3u8

# 중화질 스트림 (480p)
#EXT-X-STREAM-INF:BANDWIDTH=1400000,RESOLUTION=842x480
stream_480p.m3u8

# 고화질 스트림 (720p)
#EXT-X-STREAM-INF:BANDWIDTH=2800000,RESOLUTION=1280x720
stream_720p.m3u8

# Full HD 스트림 (1080p)
#EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
stream_1080p.m3u8

//Manifest
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:10
#EXT-X-MEDIA-SEQUENCE:0

#EXTINF:10.0,
segment1.ts
#EXTINF:10.0,
segment2.ts
#EXTINF:10.0,
segment3.ts
```

---

브라우저 정책에 따라 video 를 자동 재생하기 위해서는 음소거 상태여야 합니다. 
[크롬의 자동 재생 정책](https://developer.chrome.com/blog/autoplay?hl=ko)

## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #이슈번호
- resolves #이슈번호

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->

- [ ] 테스트 추가
- [ ] 코드 최적화
