### PR TITLE
[Feature] 카테고리 방송 목록 조회 API 추가

### DIFF
--- a/Backend/server/encoding/cleanup.sh
+++ b/Backend/server/encoding/cleanup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+LOG_FILE="/lico/script/cleanup.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+
+APP_NAME=$1
+STREAM_KEY=$2
+
+echo "Cleanup FFmpeg script for APP_NAME: $APP_NAME, STREAM_KEY: $STREAM_KEY"
+
+# API 요청으로 채널 아이디 획득
+if [[ "$APP_NAME" == "live" ]]; then
+    CHANNEL_ID=$(curl -s http://192.168.1.9:3000/lives/channel-id/$STREAM_KEY | jq -r '.channelId')
+elif [[ "$APP_NAME" == "dev" ]]; then
+    CHANNEL_ID=$(curl -s http://192.168.1.7:3000/lives/channel-id/$STREAM_KEY | jq -r '.channelId')
+else
+    echo "Error: Unsupported APP_NAME. Exiting."
+    exit 1
+fi
+
+
+if [[ "$APP_NAME" == "live" ]]; then
+    curl -X DELETE http://192.168.1.9:3000/lives/onair/$STREAM_KEY
+elif [[ "$APP_NAME" == "dev" ]]; then
+    curl -X DELETE http://192.168.1.7:3000/lives/onair/$STREAM_KEY
+else
+    echo "Error: Unsupported APP_NAME. Exiting."
+    exit 1
+fi
+
+if [[ -d "/lico/storage/$APP_NAME/$CHANNEL_ID" ]]; then
+    rm -rf "/lico/storage/$APP_NAME/$CHANNEL_ID"
+    echo "Deleted directory: /lico/storage/$APP_NAME/$CHANNEL_ID"
+else
+    echo "Directory /lico/storage/$APP_NAME/$CHANNEL_ID does not exist, skipping deletion."
+fi

--- a/Backend/server/encoding/nginx.conf
+++ b/Backend/server/encoding/nginx.conf
@@ -1,0 +1,35 @@
+user root;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+error_log /var/log/nginx/rtmp_error.log;
+
+events {
+        worker_connections 1024;
+}
+
+rtmp {
+        server {
+                listen 1935;
+
+                application live {
+                        live on;
+                        exec_publish /lico/script/stream_process.sh $app $name;
+
+                        exec_publish_done /lico/script/cleanup.sh $app $name;
+
+                        idle_streams off;
+                        access_log /var/log/nginx/rtmp_access.log;
+                        }
+                application dev {
+                        live on;
+                        exec_publish /lico/script/stream_process.sh $app $name;
+
+                        exec_publish_done /lico/script/cleanup.sh $app $name;
+
+                        idle_streams off;
+                        access_log /var/log/nginx/rtmp_access.log;
+                        }
+        }
+}

--- a/Backend/server/encoding/stream_process.sh
+++ b/Backend/server/encoding/stream_process.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#LOG_FILE="/lico/script/logfile.log"
+#exec > >(tee -a "$LOG_FILE") 2>&1
+
+APP_NAME=$1
+STREAM_KEY=$2
+
+echo "Starting FFmpeg script for APP_NAME: $APP_NAME, STREAM_KEY: $STREAM_KEY"
+
+# API 요청으로 채널 아이디 획득
+if [[ "$APP_NAME" == "live" ]]; then
+    CHANNEL_ID=$(curl -s http://192.168.1.9:3000/lives/channel-id/$STREAM_KEY | jq -r '.channelId')
+elif [[ "$APP_NAME" == "dev" ]]; then
+    CHANNEL_ID=$(curl -s http://192.168.1.7:3000/lives/channel-id/$STREAM_KEY | jq -r '.channelId')
+else
+    echo "Error: Unsupported APP_NAME. Exiting."
+    exit 1
+fi
+
+
+if [[ -z "$CHANNEL_ID" ]]; then
+    echo "Error: CHANNEL_ID is empty. Exiting."
+    exit 1
+fi
+
+# ffmpeg으로 인코딩
+ffmpeg -i "rtmp://192.168.1.6:1935/$APP_NAME/$STREAM_KEY" -y\
+        -rw_timeout 1000000 \
+    -map 0:v -map 0:a -c:a aac -b:a 192k -c:v libx264 -b:v:3 5000k -s:v:3 1920x1080 -preset superfast -profile:v baseline \
+    -map 0:v -map 0:a -c:a aac -b:a 128k -c:v libx264 -b:v:2 3000k -s:v:2 1280x720 -preset superfast -profile:v baseline \
+    -map 0:v -map 0:a -c:a aac -b:a 128k -c:v libx264 -b:v:1 1500k -s:v:1 854x480 -preset superfast -profile:v baseline \
+    -map 0:v -map 0:a -c:a aac -b:a 128k -c:v libx264 -b:v:0 800k -s:v:0 640x360 -preset superfast -profile:v baseline \
+    -hls_time 2 -hls_flags delete_segments -hls_list_size 5 \
+    -hls_segment_filename "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/%03d.ts" \ # APP_NAME(환경), CHANNEL_ID(채널 아이디)를 이용하여 오브젝트 스토리지 저장 경로를 동적으로 생성
+    -master_pl_name "index.m3u8" \
+    -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2 v:3,a:3" \
+    -f hls "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/index.m3u8" \
+    -map 0:v -vf "fps=1/10" -update 1 -s 426x240 \
+    "/lico/storage/$APP_NAME/$CHANNEL_ID/thumbnail.png"

--- a/Backend/server/ingest(srs)/lico.conf
+++ b/Backend/server/ingest(srs)/lico.conf
@@ -14,6 +14,7 @@ vhost __defaultVhost__ {
     # HTTP Hooks 설정
     http_hooks {
         enabled         on;
+        # 내부 nginx로 요청을 보내 nginx에서 바디에 담긴 app 정보를 이용해 요청을 보내는 api 서버에 분기를 준다.
         on_publish      http://localhost:3000/api/validate/publish;
     }
 

--- a/Backend/server/ingest(srs)/lico.conf
+++ b/Backend/server/ingest(srs)/lico.conf
@@ -1,0 +1,33 @@
+listen              1935;
+max_connections     1000;
+daemon              on;
+
+http_api {
+    enabled         on;
+    listen          1985;
+}
+stats {
+    network         0;
+}
+
+vhost __defaultVhost__ {
+    # HTTP Hooks 설정
+    http_hooks {
+        enabled         on;
+        on_publish      http://localhost:3000/api/validate/publish;
+    }
+
+    # RTMP 포워딩 설정
+    forward {
+        enabled on;
+        # 원본 스트림의 app과 stream name을 유지하면서 포워딩
+        destination 192.168.2.7:1935/[app]/[stream];
+    }
+
+    # WebRTC 설정
+    rtc {
+        enabled on;
+        rtc_to_rtmp on;
+    }
+
+}

--- a/Backend/server/ingest(srs)/nginx.conf
+++ b/Backend/server/ingest(srs)/nginx.conf
@@ -1,0 +1,77 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+        worker_connections 768;
+        # multi_accept on;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;   lua_shared_dict app_cache 10m;
+
+    lua_need_request_body on;
+
+    access_log /var/log/nginx/proxy_access.log;
+    error_log /var/log/nginx/proxy_error.log;
+
+    server {
+        listen 3000;
+
+        location /api/validate/publish {
+            # Lua를 이용해 본문을 읽고 app과 stream 값을 기반으로 라우팅
+            content_by_lua_block {
+                local cjson = require("cjson")
+                local http = require("resty.http")
+
+                -- 요청 본문 읽기
+                ngx.req.read_body()
+                local body = ngx.req.get_body_data()
+
+                -- JSON 본문 파싱
+                local success, data = pcall(cjson.decode, body)
+                local app = data.app
+                local stream = data.stream
+
+                -- app 값에 따라 대상 서버 결정
+                local upstream
+                if app == "live" then
+                    upstream = "http://192.168.1.9:3000/lives/onair"
+                elseif app == "dev" then                   upstream = "http://192.168.1.7:3000/lives/onair"
+                else
+                    ngx.status = ngx.HTTP_BAD_REQUEST
+                    ngx.say("Invalid app")
+                    return
+                end
+
+                -- stream 값이 있는지 확인
+                if not stream then
+                    ngx.status = ngx.HTTP_BAD_REQUEST
+                    ngx.say("Stream parameter is required")
+                    return
+                end
+
+                -- 동적 엔드포인트 설정
+                local target_url = upstream .. "/" .. stream
+
+                ngx.log(ngx.ERR, "Target URL :",target_url)
+
+                local httpc = http.new()
+
+                local res,err = httpc:request_uri(target_url, {
+                method = "POST",
+                body = body,
+                headers = {
+                ["Content-Type"] = "application/json",}})
+
+
+            ngx.status = res.status
+
+            ngx.log(ngx.ERR, "body", res.body)
+            ngx.say(res.body)
+        }
+    }
+}
+}

--- a/Backend/src/categories/categories.controller.spec.ts
+++ b/Backend/src/categories/categories.controller.spec.ts
@@ -81,7 +81,7 @@ describe('CategoriesController', () => {
     it('존재하지 않는 카테고리 ID로 조회 시 404 에러를 반환합니다.', async () => {
       // Given
       const invalidCategoryId = 999;
-      mockCategoriesService.readCategory.mockRejectedValue(new NotFoundException(ErrorMessage.READ_CATEGORY_404));
+      mockCategoriesService.readCategory.mockRejectedValue(new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND));
 
       // When & Then
       await expect(controller.getCategory(invalidCategoryId)).rejects.toThrow(

--- a/Backend/src/categories/categories.controller.spec.ts
+++ b/Backend/src/categories/categories.controller.spec.ts
@@ -85,7 +85,7 @@ describe('CategoriesController', () => {
 
       // When & Then
       await expect(controller.getCategory(invalidCategoryId)).rejects.toThrow(
-        new NotFoundException(ErrorMessage.READ_CATEGORY_404),
+        new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND),
       );
       expect(categoriesService.readCategory).toHaveBeenCalledTimes(1);
       expect(categoriesService.readCategory).toHaveBeenCalledWith(invalidCategoryId);

--- a/Backend/src/categories/categories.controller.ts
+++ b/Backend/src/categories/categories.controller.ts
@@ -21,7 +21,7 @@ export class CategoriesController {
     return await this.categoriesService.readCategory(categoriesId);
   }
 
-  @Get('/:catrgoriesId/lives')
+  @Get('/:categoriesId/lives')
   async getOnAirLivesByCategory(@Param('categoriesId', ParseIntPipe) categoriesId: number) {
     return await this.livesService.readLives({ categoriesId, onAir: true });
   }

--- a/Backend/src/categories/categories.controller.ts
+++ b/Backend/src/categories/categories.controller.ts
@@ -1,11 +1,15 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CategoriesDto } from './dto/categories.dto';
 import { CategoryDto } from './dto/category.dto';
+import { LivesService } from './../lives/lives.service';
 
 @Controller('categories')
 export class CategoriesController {
-  constructor(private readonly categoriesService: CategoriesService) {}
+  constructor(
+    private readonly categoriesService: CategoriesService,
+    private readonly livesService: LivesService,
+  ) {}
 
   @Get()
   async getCategories(): Promise<CategoriesDto[]> {
@@ -13,7 +17,12 @@ export class CategoriesController {
   }
 
   @Get('/:categoriesId')
-  async getCategory(@Param('categoriesId') categoriesId: number): Promise<CategoryDto> {
+  async getCategory(@Param('categoriesId', ParseIntPipe) categoriesId: number): Promise<CategoryDto> {
     return await this.categoriesService.readCategory(categoriesId);
+  }
+
+  @Get('/:catrgoriesId/lives')
+  async getOnAirLivesByCategory(@Param('categoriesId', ParseIntPipe) categoriesId: number) {
+    return await this.livesService.readLives({ categoriesId, onAir: true });
   }
 }

--- a/Backend/src/categories/categories.module.ts
+++ b/Backend/src/categories/categories.module.ts
@@ -3,9 +3,10 @@ import { CategoriesController } from './categories.controller';
 import { CategoriesService } from './categories.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CategoryEntity } from './entity/category.entity';
+import { LivesModule } from 'src/lives/lives.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([CategoryEntity])],
+  imports: [TypeOrmModule.forFeature([CategoryEntity]), LivesModule],
   controllers: [CategoriesController],
   providers: [CategoriesService],
 })

--- a/Backend/src/categories/categories.service.spec.ts
+++ b/Backend/src/categories/categories.service.spec.ts
@@ -99,7 +99,7 @@ describe('CategoriesService', () => {
 
       // When & Then
       await expect(service.readCategory(invalidCategoryId)).rejects.toThrow(
-        new NotFoundException(ErrorMessage.READ_CATEGORY_404),
+        new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND),
       );
       expect(repository.findOne).toHaveBeenCalledTimes(1);
       expect(repository.findOne).toHaveBeenCalledWith({

--- a/Backend/src/categories/categories.service.ts
+++ b/Backend/src/categories/categories.service.ts
@@ -25,7 +25,7 @@ export class CategoriesService {
     const category = await this.categoriesRepository.findOne({ where: { id } });
 
     if (!category) {
-      throw new NotFoundException(ErrorMessage.READ_CATEGORY_404);
+      throw new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND);
     }
 
     return { name: category.name, image: category.image };

--- a/Backend/src/categories/error/error.message.enum.ts
+++ b/Backend/src/categories/error/error.message.enum.ts
@@ -1,3 +1,3 @@
 export enum ErrorMessage {
-  READ_CATEGORY_404 = '등록되지 않은 카테고리입니다.',
+  CATEGORY_NOT_FOUND = '존재하지 않는 카테고리입니다.',
 }

--- a/Backend/src/config/typeorm.config.ts
+++ b/Backend/src/config/typeorm.config.ts
@@ -10,4 +10,5 @@ export const typeOrmConfig = (configService: ConfigService): TypeOrmModuleOption
   database: configService.get<string>('DB_NAME'),
   entities: [__dirname + '/../**/*.entity.{js,ts}'],
   synchronize: true,
+  logging: true,
 });

--- a/Backend/src/lives/dto/live.dto.ts
+++ b/Backend/src/lives/dto/live.dto.ts
@@ -6,4 +6,5 @@ export class LiveDto {
   readonly usersProfileImage: string;
   readonly categoriesId: number | null;
   readonly categoriesName: string | null;
+  readonly onAir: boolean | null;
 }

--- a/Backend/src/lives/dto/lives.dto.ts
+++ b/Backend/src/lives/dto/lives.dto.ts
@@ -5,4 +5,5 @@ export class LivesDto {
   readonly usersProfileImage: string;
   readonly categoriesId: number | null;
   readonly categoriesName: string | null;
+  readonly onAir: boolean | null;
 }

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -77,6 +77,7 @@ export class LiveEntity {
       startedAt: this.startedAt,
       usersNickname: this.user.nickname,
       usersProfileImage: this.user.profileImage,
+      onAir: this.onAir,
     };
   }
 }

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -64,6 +64,7 @@ export class LiveEntity {
       channelId: this.channelId,
       usersNickname: this.user.nickname,
       usersProfileImage: this.user.profileImage,
+      onAir: this.onAir,
     };
   }
 

--- a/Backend/src/lives/error/error.message.enum.ts
+++ b/Backend/src/lives/error/error.message.enum.ts
@@ -1,0 +1,4 @@
+export enum ErrorMessage {
+  LIVE_NOT_FOUND = '존재하지 않는 채널입니다.',
+  LIVE_ALREADY_STARTED = '이미 방송이 진행중입니다.',
+}

--- a/Backend/src/lives/lives.controller.spec.ts
+++ b/Backend/src/lives/lives.controller.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { LivesController } from './lives.controller';
 import { LivesService } from './lives.service';
 import { LivesDto } from './dto/lives.dto';
-import { NotFoundException } from '@nestjs/common';
 
 describe('LivesController', () => {
   let controller: LivesController;
@@ -16,6 +15,7 @@ describe('LivesController', () => {
       usersProfileImage: 'https://example.com/profile.jpg',
       categoriesId: 1,
       categoriesName: 'Gaming',
+      onAir: true,
     },
     {
       channelId: 'def456',
@@ -24,6 +24,7 @@ describe('LivesController', () => {
       usersProfileImage: 'https://example.com/jane-profile.jpg',
       categoriesId: 2,
       categoriesName: 'Music',
+      onAir: true,
     },
   ];
 
@@ -51,16 +52,17 @@ describe('LivesController', () => {
     jest.clearAllMocks();
   });
 
-  describe('getLives', () => {
-    it('라이브 컨트롤러가 라이브 목록을 반환합니다.', async () => {
+  describe('getOnAirLives', () => {
+    it('라이브 컨트롤러가 방송중인 라이브 목록을 반환합니다.', async () => {
       // Given
       mockLivesService.readLives.mockResolvedValue(mockLives);
 
       // When
-      const lives = await controller.getLives();
+      const lives = await controller.getOnAirLives();
 
       // Then
       expect(service.readLives).toHaveBeenCalledTimes(1);
+      expect(service.readLives).toHaveBeenCalledWith({ onAir: true });
       expect(lives).toEqual(mockLives);
     });
   });

--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -10,8 +10,8 @@ export class LivesController {
   constructor(private readonly livesService: LivesService) {}
 
   @Get()
-  async getLives(): Promise<LivesDto[]> {
-    return await this.livesService.readLives();
+  async getOnAirLives(): Promise<LivesDto[]> {
+    return await this.livesService.readLives({ onAir: true });
   }
 
   @Get('/:channelId')

--- a/Backend/src/lives/lives.module.ts
+++ b/Backend/src/lives/lives.module.ts
@@ -8,5 +8,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
   imports: [TypeOrmModule.forFeature([LiveEntity])],
   providers: [LivesService],
   controllers: [LivesController],
+  exports: [LivesService],
 })
 export class LivesModule {}

--- a/Backend/src/lives/lives.service.spec.ts
+++ b/Backend/src/lives/lives.service.spec.ts
@@ -118,14 +118,14 @@ describe('LivesService', () => {
   describe('readLives', () => {
     it('라이브 서비스가 라이브 목록을 반환합니다.', async () => {
       // Given
-      mockLivesRepository.find.mockResolvedValue(mockLives.filter(entity => entity.onAir));
+      mockLivesRepository.find.mockResolvedValue(mockLives);
 
       // When
       const lives = await service.readLives();
 
       // Then
       expect(repository.find).toHaveBeenCalledTimes(1);
-      expect(repository.find).toHaveBeenCalledWith({ relations: ['category', 'user'], where: { onAir: true } });
+      expect(repository.find).toHaveBeenCalledWith({ relations: ['category', 'user'], where: {} });
       expect(lives).toEqual([
         {
           categoriesId: 1,
@@ -134,6 +134,7 @@ describe('LivesService', () => {
           channelId: 'abc123',
           usersNickname: 'JohnDoe',
           usersProfileImage: 'https://example.com/profile.jpg',
+          onAir: true,
         },
         {
           categoriesId: 2,
@@ -142,6 +143,16 @@ describe('LivesService', () => {
           channelId: 'def456',
           usersNickname: 'JaneDoe',
           usersProfileImage: 'https://example.com/jane-profile.jpg',
+          onAir: true,
+        },
+        {
+          categoriesId: 3,
+          categoriesName: 'Talk Show',
+          channelId: 'ghi789',
+          livesName: 'Evening Talk Show',
+          usersNickname: 'HostName',
+          usersProfileImage: 'https://example.com/host-profile.jpg',
+          onAir: false,
         },
       ]);
     });

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { LiveEntity } from './entity/live.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsWhere, Repository } from 'typeorm';
@@ -21,6 +21,11 @@ export class LivesService {
 
   async readLive(channelId: string): Promise<LiveDto> {
     const live = await this.livesRepository.findOne({ relations: ['category', 'user'], where: { channelId } });
+
+    if (!live) {
+      throw new NotFoundException('존재하지 않는 채널입니다.');
+    }
+
     return live.toLiveDto();
   }
 

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -1,7 +1,7 @@
 import { ConflictException, Injectable } from '@nestjs/common';
 import { LiveEntity } from './entity/live.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 import { LivesDto } from './dto/lives.dto';
 import { LiveDto } from './dto/live.dto';
 import { UUID } from 'crypto';
@@ -10,9 +10,12 @@ import { UUID } from 'crypto';
 export class LivesService {
   constructor(@InjectRepository(LiveEntity) private livesRepository: Repository<LiveEntity>) {}
 
-  async readLives(): Promise<LivesDto[]> {
+  async readLives(where: FindOptionsWhere<LiveEntity> = {}): Promise<LivesDto[]> {
     // TODO 데이터 베이스 뷰 추가
-    const lives = await this.livesRepository.find({ relations: ['category', 'user'], where: { onAir: true } });
+    const lives = await this.livesRepository.find({
+      relations: ['category', 'user'],
+      where,
+    });
     return lives.map(entity => entity.toLivesDto());
   }
 

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -5,6 +5,7 @@ import { FindOptionsWhere, Repository } from 'typeorm';
 import { LivesDto } from './dto/lives.dto';
 import { LiveDto } from './dto/live.dto';
 import { UUID } from 'crypto';
+import { ErrorMessage } from './error/error.message.enum';
 
 @Injectable()
 export class LivesService {
@@ -23,7 +24,7 @@ export class LivesService {
     const live = await this.livesRepository.findOne({ relations: ['category', 'user'], where: { channelId } });
 
     if (!live) {
-      throw new NotFoundException('존재하지 않는 채널입니다.');
+      throw new NotFoundException(ErrorMessage.LIVE_NOT_FOUND);
     }
 
     return live.toLiveDto();
@@ -43,7 +44,7 @@ export class LivesService {
     const live = await this.livesRepository.findOne({ where: { streamingKey } });
 
     if (live.onAir) {
-      throw new ConflictException('이미 방송이 진행중입니다.');
+      throw new ConflictException(ErrorMessage.LIVE_ALREADY_STARTED);
     }
 
     await this.livesRepository.update({ streamingKey }, { startedAt: new Date(), onAir: true });


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
카테고리에서 미구현하였던 카테고리 방송 목록 조회 API 추가

미디어 서버를 분리하였습니다.
1. ingest 서버는 lico.conf 에 따라 rtmp와 werbrtc 입력을 encoding 서버에 rtmp로 전송합니다.
이때 api 서버에 스트림키에 해당하는 채널이 이미 방송 진행중인지 아닌지를 체크합니다.
크레딧 사정 상 ingest 서버를 dev와 live 환경으로 분리하지 멋하여 api 검증 요청을 내부의 nginx로 보낸 뒤
nginx 에서 api 요청의 body 에 따라 api 서버를 지정하여 요청을 전송합니다.
(설정에서 url만 지정 가능하고 메서드 및 바디가 지정되어있으며 동적 url 생성이 불가능 하여 이러한 방법을 선택하였습니다.)
2. encoding 서버는 nginx-rtmp 모듈을 이용하여 ingest 서버가 rtmp 요청을 전송하면 stream_process.sh 스크립트를 실행하고 전송이 종료되면 cleanup.sh 스크립트를 실행합니다.
stream_process.sh 에서는 여러 화질로 영상을 인코딩하여 오브젝트 스토리지에 저장합니다.
cleanup.sh 에서는 오브젝트 스토리지에 저장된 영상 파일을 제거합니다.


## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->
1. 카테고리 방송 목록 조회 API를 추가하였습니다.
2. ingest 서버, encoding 서버에서 사용중인 스크립트 및 nginx 설정 파일을 추가하였습니다.
4. 채널 상세 정보 조회 시 조회된 정보가 없으면 404 에러를 반환하도록 하였습니다.
5. 방송 목록 획득 시 조건을 입력하여 목록을 받아올 수 있게 함수를 리팩터링 하였습니다.

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->

- [ ] 테스트 추가
