### PR TITLE
[Feature] auth/refresh api 구현

### DIFF
--- a/Backend/src/auth/auth.service.ts
+++ b/Backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
@@ -45,8 +45,6 @@ export class AuthService {
       this.jwtService.signAsync({ ...payload, type: 'refresh' }, { expiresIn: '7d' }),
     ]);
 
-    console.log('accessToken :', accessToken)
-
     return {
       accessToken,
       refreshToken,
@@ -54,7 +52,63 @@ export class AuthService {
         id: user.id,
         nickname: user.nickname,
         profileImage: user.profileImage,
+        channelId: user.live ? user.live.channelId : null, // channelId 추가
+        liveId: user.live ? user.live.id : null, // liveId 추가
       },
     };
+  }
+
+  // Refresh 토큰 재발급
+  async refreshTokens(refreshToken: string) {
+    try {
+      const payload = await this.jwtService.verifyAsync(refreshToken, {
+        secret: this.configService.get<string>('JWT_SECRET'),
+      });
+
+      if (payload.type !== 'refresh') {
+        throw new UnauthorizedException('Invalid token type');
+      }
+
+      const userId = payload.sub.id;
+      const oauthPlatform = payload.sub.provider;
+
+      // 사용자 조회
+      const user = await this.usersService.findById(userId);
+      if (!user) {
+        throw new UnauthorizedException('User not found');
+      }
+
+      // 새로운 토큰 페이로드 구성
+      const newPayload = {
+        sub: {
+          id: user.id,
+          provider: user.oauthPlatform,
+        },
+      };
+
+      // 새로운 Access 및 Refresh 토큰 생성
+      const [newAccessToken, newRefreshToken] = await Promise.all([
+        this.jwtService.signAsync(newPayload, { expiresIn: '1h' }),
+        this.jwtService.signAsync(
+          { ...newPayload, type: 'refresh' },
+          { expiresIn: '7d' },
+        ),
+      ]);
+
+      return {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        user: {
+          id: user.id,
+          nickname: user.nickname,
+          profileImage: user.profileImage,
+          channelId: user.live.channelId, // channelId 추가
+          liveId: user.live.id, // liveId 추가
+        },
+      };
+    } catch (error) {
+      console.error('Refresh Token Error:', error);
+      throw new UnauthorizedException('Invalid refresh token');
+    }
   }
 }

--- a/Backend/src/users/dto/create.user.dto.ts
+++ b/Backend/src/users/dto/create.user.dto.ts
@@ -1,8 +1,13 @@
 import { IsString, IsEnum, IsOptional, IsUrl } from 'class-validator';
-
 export class CreateUserDto {
+  @IsString()
   oauthUid: string;
+  @IsEnum(['naver', 'github', 'google'])
   oauthPlatform: 'naver' | 'github' | 'google';
-  nickname: string;
-  profileImage?: string;
+  @IsString()
+  @IsOptional()
+  nickname?: string;
+  @IsUrl()
+  @IsOptional()
+  profileImage?: string | null;
 }

--- a/Backend/src/users/users.service.ts
+++ b/Backend/src/users/users.service.ts
@@ -19,16 +19,21 @@ export class UsersService {
     private connection: DataSource,
   ) {}
 
-  async findByOAuthUid(oauthUid: string, oauthPlatform: 'naver' | 'github' | 'google'): Promise<UserEntity | null> {
-    // undefined 대신 null 사용
+  async findByOAuthUid(
+    oauthUid: string,
+    oauthPlatform: 'naver' | 'github' | 'google',
+  ): Promise<UserEntity | null> {
     return this.usersRepository.findOne({
       where: { oauthUid, oauthPlatform },
+      relations: ['live'], // live 관계 추가
     });
   }
 
   async findById(id: number): Promise<UserEntity | null> {
-    // undefined 대신 null 사용
-    return this.usersRepository.findOne({ where: { id } });
+    return this.usersRepository.findOne({
+      where: { id },
+      relations: ['live'], // live 관계 추가
+    });
   }
 
   async createUser(createUserDto: CreateUserDto): Promise<UserEntity> {


### PR DESCRIPTION
## 📝 PR 설명
auth/refresh api 구현했습니다. 프론트에서 테스트 부탁드립니다. 또한 access 토큰에 liveId, chennelId 등을 추가했습니다.

## ✅ 주요 변경 사항
- [ ] `auth/refresh` api 구현
- [ ] access 토큰에 liveId, chennelId 등을 추가

## 📸 스크린샷 (선택)
### accessToken 에 포함된 값
![image](https://github.com/user-attachments/assets/30160a6e-bb9c-45fc-b446-cc5bc438fae7)

## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)

