### PR TITLE
[Feature] users api 구현

### DIFF
--- a/Backend/src/auth/auth.service.ts
+++ b/Backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
@@ -45,8 +45,6 @@ export class AuthService {
       this.jwtService.signAsync({ ...payload, type: 'refresh' }, { expiresIn: '7d' }),
     ]);
 
-    console.log('accessToken :', accessToken)
-
     return {
       accessToken,
       refreshToken,
@@ -54,7 +52,63 @@ export class AuthService {
         id: user.id,
         nickname: user.nickname,
         profileImage: user.profileImage,
+        channelId: user.live ? user.live.channelId : null, // channelId 추가
+        liveId: user.live ? user.live.id : null, // liveId 추가
       },
     };
+  }
+
+  // Refresh 토큰 재발급
+  async refreshTokens(refreshToken: string) {
+    try {
+      const payload = await this.jwtService.verifyAsync(refreshToken, {
+        secret: this.configService.get<string>('JWT_SECRET'),
+      });
+
+      if (payload.type !== 'refresh') {
+        throw new UnauthorizedException('Invalid token type');
+      }
+
+      const userId = payload.sub.id;
+      const oauthPlatform = payload.sub.provider;
+
+      // 사용자 조회
+      const user = await this.usersService.findById(userId);
+      if (!user) {
+        throw new UnauthorizedException('User not found');
+      }
+
+      // 새로운 토큰 페이로드 구성
+      const newPayload = {
+        sub: {
+          id: user.id,
+          provider: user.oauthPlatform,
+        },
+      };
+
+      // 새로운 Access 및 Refresh 토큰 생성
+      const [newAccessToken, newRefreshToken] = await Promise.all([
+        this.jwtService.signAsync(newPayload, { expiresIn: '1h' }),
+        this.jwtService.signAsync(
+          { ...newPayload, type: 'refresh' },
+          { expiresIn: '7d' },
+        ),
+      ]);
+
+      return {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        user: {
+          id: user.id,
+          nickname: user.nickname,
+          profileImage: user.profileImage,
+          channelId: user.live.channelId, // channelId 추가
+          liveId: user.live.id, // liveId 추가
+        },
+      };
+    } catch (error) {
+      console.error('Refresh Token Error:', error);
+      throw new UnauthorizedException('Invalid refresh token');
+    }
   }
 }

--- a/Backend/src/users/dto/create.user.dto.ts
+++ b/Backend/src/users/dto/create.user.dto.ts
@@ -1,8 +1,13 @@
 import { IsString, IsEnum, IsOptional, IsUrl } from 'class-validator';
-
 export class CreateUserDto {
+  @IsString()
   oauthUid: string;
+  @IsEnum(['naver', 'github', 'google'])
   oauthPlatform: 'naver' | 'github' | 'google';
-  nickname: string;
-  profileImage?: string;
+  @IsString()
+  @IsOptional()
+  nickname?: string;
+  @IsUrl()
+  @IsOptional()
+  profileImage?: string | null;
 }

--- a/Backend/src/users/dto/update.user.dto.ts
+++ b/Backend/src/users/dto/update.user.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @IsOptional()
+  @IsUrl()
+  profileImage?: string | null;
+}

--- a/Backend/src/users/users.controller.ts
+++ b/Backend/src/users/users.controller.ts
@@ -1,13 +1,61 @@
-import { Controller, Get, UseGuards, Req } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Put,
+  UseGuards,
+  Req,
+  Param,
+  Body,
+  ForbiddenException,
+  NotFoundException,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { Request } from 'express';
 import { UserEntity } from './entity/user.entity';
+import { UsersService } from './users.service';
+import { UpdateUserDto } from './dto/update.user.dto';
 
 @Controller('users')
 export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  // 사용자 프로필 조회
   @Get('/:userId')
-  @UseGuards(JwtAuthGuard) // Guard 적용
-  getProfile(@Req() req: Request & { user: UserEntity }) {
-    return req.user;
+  async getProfile(@Param('userId', ParseIntPipe) userId: number) {
+    const user = await this.usersService.findById(userId);
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    return {
+      users_id: user.id,
+      nickname: user.nickname,
+      profile_image: user.profileImage,
+      created_at: user.createdAt,
+    };
+  }
+
+  // 사용자 프로필 업데이트
+  @Put('/:userId')
+  @UseGuards(JwtAuthGuard)
+  async updateProfile(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Req() req: Request & { user: UserEntity },
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    // 요청한 사용자가 본인인지 확인
+    if (req.user.id !== userId) {
+      throw new ForbiddenException('본인만 프로필을 수정할 수 있습니다.');
+    }
+
+    const updatedUser = await this.usersService.updateUser(userId, updateUserDto);
+
+    return {
+      users_id: updatedUser.id,
+      nickname: updatedUser.nickname,
+      profile_image: updatedUser.profileImage,
+      created_at: updatedUser.createdAt,
+    };
   }
 }

--- a/Backend/src/users/users.service.ts
+++ b/Backend/src/users/users.service.ts
@@ -19,16 +19,21 @@ export class UsersService {
     private connection: DataSource,
   ) {}
 
-  async findByOAuthUid(oauthUid: string, oauthPlatform: 'naver' | 'github' | 'google'): Promise<UserEntity | null> {
-    // undefined 대신 null 사용
+  async findByOAuthUid(
+    oauthUid: string,
+    oauthPlatform: 'naver' | 'github' | 'google',
+  ): Promise<UserEntity | null> {
     return this.usersRepository.findOne({
       where: { oauthUid, oauthPlatform },
+      relations: ['live'], // live 관계 추가
     });
   }
 
   async findById(id: number): Promise<UserEntity | null> {
-    // undefined 대신 null 사용
-    return this.usersRepository.findOne({ where: { id } });
+    return this.usersRepository.findOne({
+      where: { id },
+      relations: ['live'], // live 관계 추가
+    });
   }
 
   async createUser(createUserDto: CreateUserDto): Promise<UserEntity> {

--- a/Backend/src/users/users.service.ts
+++ b/Backend/src/users/users.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository, InjectDataSource } from '@nestjs/typeorm';
 import { UserEntity } from './entity/user.entity';
 import { LiveEntity } from '../lives/entity/live.entity';
 import { Repository, DataSource } from 'typeorm';
 import { CreateUserDto } from './dto/create.user.dto';
+import { UpdateUserDto } from './dto/update.user.dto';
 import { randomUUID } from 'crypto';
 
 @Injectable()
@@ -25,14 +26,14 @@ export class UsersService {
   ): Promise<UserEntity | null> {
     return this.usersRepository.findOne({
       where: { oauthUid, oauthPlatform },
-      relations: ['live'], // live 관계 추가
+      relations: ['live'],
     });
   }
 
   async findById(id: number): Promise<UserEntity | null> {
     return this.usersRepository.findOne({
       where: { id },
-      relations: ['live'], // live 관계 추가
+      relations: ['live'],
     });
   }
 
@@ -55,5 +56,23 @@ export class UsersService {
       });
       return await manager.save(UserEntity, newUser);
     });
+  }
+  // 사용자 프로필 업데이트 메서드 추가
+  async updateUser(userId: number, updateUserDto: UpdateUserDto): Promise<UserEntity> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    if (updateUserDto.nickname !== undefined) {
+      user.nickname = updateUserDto.nickname;
+    }
+
+    if (updateUserDto.profileImage !== undefined) {
+      user.profileImage = updateUserDto.profileImage;
+    }
+
+    return await this.usersRepository.save(user);
   }
 }


### PR DESCRIPTION
## 📝 PR 설명
`/users/{userId}` method `PUT`, `GET` 2개 api 구현 
- `PUT` 메서드는 본인이 프로필 정보를 바꾸는 요청
- `GET` 메서드는 임의의 사용자가 다른 사용자의 프로필 이미지나 닉네임을 클릭하거나, 본인의 프로필 페이지에 들어갈 때, 요청

## ✅ 주요 변경 사항
- `/users/dto/update.user.dto.ts` 생성 
- `users.service.ts` 의 `updateUser` 메서드 구현
- `users.controller.ts` 의 `updateProfile` 메서드 구현

## 📸 스크린샷 
```
// 20241114014910
// http://localhost:3001/users/1

{
  "users_id": 1,
  "nickname": "최명권",
  "profile_image": "https://lh3.googleusercontent.com/a/ACg8ocL6Ts4DJlhhoZAYnORFNloeRd11R63nW09FMyDjccfpWoWnud8g=s96-c",
  "created_at": "2024-11-13T12:50:11.660Z"
}
```
- 이미지는 아니지만, `/users/{userId}` 를 `GET` 했을 때 결과
## 🔗 관련 이슈
- closes #141 

## 🛠️ 추가 작업 (선택)
- [ ] PUT 요청은 테스트 하지 못함, 프론트 구현 후 테스트
