### PR TITLE
[Fix] 토큰 요청시 401 응답 받았을 때 무한루프 대신 홈으로 리다이렉트

### DIFF
--- a/Frontend/src/apis/axios.ts
+++ b/Frontend/src/apis/axios.ts
@@ -29,15 +29,16 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const response = await api.post<RefreshTokenResponse>('/auth/refresh');
-        const { accessToken, user } = response.data;
+        const refreshResponse = await api.post<RefreshTokenResponse>('/auth/refresh');
+        const { accessToken, user } = refreshResponse.data;
 
         useAuthStore.getState().setAuth({ accessToken, user });
         originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+
         return api(originalRequest);
       } catch (refreshError) {
         useAuthStore.getState().clearAuth();
-        window.location.href = '/login';
+        window.location.href = '/';
         return Promise.reject(refreshError);
       }
     }


### PR DESCRIPTION
## 📝 PR 설명
*  토큰 요청시 401 응답 받았을 때 무한루프 대신 홈으로 리다이렉트
## ✅ 주요 변경 사항
*  토큰 요청시 401 응답 받았을 때 무한루프 대신 홈으로 리다이렉트

