### PR TITLE
[Feature] follow-api 생성

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeOrmConfig } from './config/typeorm.config';
 import { LivesModule } from './lives/lives.module';
 import { ChatsModule } from './chats/chats.module';
+import { FollowModule } from './follow/follow.module';
 import sqliteConfig from './config/sqlite.config';
 import mysqlConfig from './config/mysql.config';
 
@@ -30,6 +31,7 @@ import mysqlConfig from './config/mysql.config';
     VideosModule,
     LivesModule,
     ChatsModule,
+    FollowModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/Backend/src/auth/auth.controller.ts
+++ b/Backend/src/auth/auth.controller.ts
@@ -83,7 +83,7 @@ export class AuthController {
         domain: '.lico.digital',
         path: '/',
       });
-      console.log(`accessToken :      ${accessToken}`)
+
       res.json({
         success: true,
         accessToken,

--- a/Backend/src/auth/auth.controller.ts
+++ b/Backend/src/auth/auth.controller.ts
@@ -83,7 +83,7 @@ export class AuthController {
         domain: '.lico.digital',
         path: '/',
       });
-
+      console.log(`accessToken :      ${accessToken}`)
       res.json({
         success: true,
         accessToken,

--- a/Backend/src/follow/follow.controller.spec.ts
+++ b/Backend/src/follow/follow.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FollowController } from './follow.controller';
+
+describe('FollowController', () => {
+  let controller: FollowController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FollowController],
+    }).compile();
+
+    controller = module.get<FollowController>(FollowController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/Backend/src/follow/follow.controller.ts
+++ b/Backend/src/follow/follow.controller.ts
@@ -1,0 +1,54 @@
+// src/follow/follow.controller.ts
+
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  UseGuards,
+  Req,
+  Param,
+  Body,
+  HttpCode,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { FollowService } from './follow.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { Request } from 'express';
+import { UserEntity } from '../users/entity/user.entity';
+
+@Controller('follow')
+@UseGuards(JwtAuthGuard)
+export class FollowController {
+  constructor(private readonly followService: FollowService) {}
+
+  // 팔로우한 스트리머 목록 조회
+  @Get()
+  async getFollowing(@Req() req: Request & { user: UserEntity }) {
+    const userId = req.user.id;
+    return this.followService.getFollowingStreamers(userId);
+  }
+
+  // 스트리머 팔로우
+  @Post()
+  @HttpCode(201)
+  async followStreamer(
+    @Req() req: Request & { user: UserEntity },
+    @Body('streamerId', ParseIntPipe) streamerId: number,
+  ) {
+    const userId = req.user.id;
+    await this.followService.followStreamer(userId, streamerId);
+    return { message: '팔로우 성공' };
+  }
+
+  // 스트리머 언팔로우
+  @Delete(':streamerId')
+  async unfollowStreamer(
+    @Req() req: Request & { user: UserEntity },
+    @Param('streamerId', ParseIntPipe) streamerId: number,
+  ) {
+    const userId = req.user.id;
+    await this.followService.unfollowStreamer(userId, streamerId);
+    return { message: '언팔로우 성공' };
+  }
+}

--- a/Backend/src/follow/follow.controller.ts
+++ b/Backend/src/follow/follow.controller.ts
@@ -1,5 +1,3 @@
-// src/follow/follow.controller.ts
-
 import {
   Controller,
   Get,
@@ -8,7 +6,6 @@ import {
   UseGuards,
   Req,
   Param,
-  Body,
   HttpCode,
   ParseIntPipe,
 } from '@nestjs/common';
@@ -30,11 +27,11 @@ export class FollowController {
   }
 
   // 스트리머 팔로우
-  @Post()
+  @Post(':streamerId')
   @HttpCode(201)
   async followStreamer(
     @Req() req: Request & { user: UserEntity },
-    @Body('streamerId', ParseIntPipe) streamerId: number,
+    @Param('streamerId', ParseIntPipe) streamerId: number,
   ) {
     const userId = req.user.id;
     await this.followService.followStreamer(userId, streamerId);

--- a/Backend/src/follow/follow.module.ts
+++ b/Backend/src/follow/follow.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { FollowService } from './follow.service';
+import { FollowController } from './follow.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserEntity } from '../users/entity/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserEntity])],
+  providers: [FollowService],
+  controllers: [FollowController],
+})
+export class FollowModule {}

--- a/Backend/src/follow/follow.service.spec.ts
+++ b/Backend/src/follow/follow.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FollowService } from './follow.service';
+
+describe('FollowService', () => {
+  let service: FollowService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FollowService],
+    }).compile();
+
+    service = module.get<FollowService>(FollowService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/Backend/src/follow/follow.service.ts
+++ b/Backend/src/follow/follow.service.ts
@@ -21,7 +21,7 @@ export class FollowService {
       relations: ['following'],
     });
 
-    const streamer = await this.usersRepository.findOne({ where: { id: streamerId } });
+    const streamer = await this.usersRepository.findOneBy({ id: streamerId });
 
     if (!user || !streamer) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
@@ -68,7 +68,7 @@ export class FollowService {
   async getFollowingStreamers(userId: number): Promise<any[]> {
     const user = await this.usersRepository.findOne({
       where: { id: userId },
-      relations: ['following', 'following.live', 'following.live.category'],
+      relations: ['following', 'following.live'],
     });
 
     if (!user) {
@@ -76,9 +76,6 @@ export class FollowService {
     }
 
     return user.following.map((streamer) => ({
-      categoriesId: streamer.live?.category?.id || null,
-      categoriesName: streamer.live?.category?.name || null,
-      livesName: streamer.live?.name || null,
       channelId: streamer.live?.channelId || null,
       usersNickname: streamer.nickname,
       usersProfileImage: streamer.profileImage,

--- a/Backend/src/follow/follow.service.ts
+++ b/Backend/src/follow/follow.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { UserEntity } from '../users/entity/user.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class FollowService {
+  constructor(
+    @InjectRepository(UserEntity)
+    private usersRepository: Repository<UserEntity>,
+  ) {}
+
+  // 스트리머 팔로우
+  async followStreamer(userId: number, streamerId: number): Promise<void> {
+    if (userId === streamerId) {
+      throw new BadRequestException('자기 자신을 팔로우할 수 없습니다.');
+    }
+
+    const user = await this.usersRepository.findOne({
+      where: { id: userId },
+      relations: ['following'],
+    });
+
+    const streamer = await this.usersRepository.findOne({ where: { id: streamerId } });
+
+    if (!user || !streamer) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    // 이미 팔로우 중인지 확인
+    const isAlreadyFollowing = user.following.some(
+      (followedUser) => followedUser.id === streamerId,
+    );
+
+    if (isAlreadyFollowing) {
+      throw new BadRequestException('이미 팔로우 중입니다.');
+    }
+
+    user.following.push(streamer);
+    await this.usersRepository.save(user);
+  }
+
+  // 스트리머 언팔로우
+  async unfollowStreamer(userId: number, streamerId: number): Promise<void> {
+    const user = await this.usersRepository.findOne({
+      where: { id: userId },
+      relations: ['following'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    // 팔로우 중인지 확인
+    const index = user.following.findIndex(
+      (followedUser) => followedUser.id === streamerId,
+    );
+
+    if (index === -1) {
+      throw new BadRequestException('팔로우 중인 스트리머가 아닙니다.');
+    }
+
+    user.following.splice(index, 1);
+    await this.usersRepository.save(user);
+  }
+
+  // 팔로우한 스트리머 목록 조회
+  async getFollowingStreamers(userId: number): Promise<any[]> {
+    const user = await this.usersRepository.findOne({
+      where: { id: userId },
+      relations: ['following', 'following.live', 'following.live.category'],
+    });
+
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    return user.following.map((streamer) => ({
+      categoriesId: streamer.live?.category?.id || null,
+      categoriesName: streamer.live?.category?.name || null,
+      livesName: streamer.live?.name || null,
+      channelId: streamer.live?.channelId || null,
+      usersNickname: streamer.nickname,
+      usersProfileImage: streamer.profileImage,
+      onAir: streamer.live?.onAir || false,
+    }));
+  }
+}

--- a/Backend/src/follow/follow.service.ts
+++ b/Backend/src/follow/follow.service.ts
@@ -68,7 +68,7 @@ export class FollowService {
   async getFollowingStreamers(userId: number): Promise<any[]> {
     const user = await this.usersRepository.findOne({
       where: { id: userId },
-      relations: ['following', 'following.live'],
+      relations: ['following', 'following.live','following.live.category'],
     });
 
     if (!user) {
@@ -76,6 +76,9 @@ export class FollowService {
     }
 
     return user.following.map((streamer) => ({
+      categoriesId: streamer.live?.category?.id || null,
+      categoriesName: streamer.live?.category?.name || null,
+      livesName: streamer.live?.name || null,
       channelId: streamer.live?.channelId || null,
       usersNickname: streamer.nickname,
       usersProfileImage: streamer.profileImage,

--- a/Backend/src/users/dto/create.user.dto.ts
+++ b/Backend/src/users/dto/create.user.dto.ts
@@ -2,11 +2,14 @@ import { IsString, IsEnum, IsOptional, IsUrl } from 'class-validator';
 export class CreateUserDto {
   @IsString()
   oauthUid: string;
+  
   @IsEnum(['naver', 'github', 'google'])
   oauthPlatform: 'naver' | 'github' | 'google';
+  
   @IsString()
   @IsOptional()
   nickname?: string;
+  
   @IsUrl()
   @IsOptional()
   profileImage?: string | null;

--- a/Backend/src/users/entity/user.entity.ts
+++ b/Backend/src/users/entity/user.entity.ts
@@ -8,6 +8,8 @@ import {
   DeleteDateColumn,
   OneToOne,
   JoinColumn,
+  ManyToMany,
+  JoinTable,
 } from 'typeorm';
 
 @Entity('users')
@@ -44,4 +46,19 @@ export class UserEntity {
   @OneToOne(() => LiveEntity)
   @JoinColumn({ name: 'lives_id' })
   live: LiveEntity;
+
+    // 👇 following 프로퍼티 추가
+    @ManyToMany(() => UserEntity)
+    @JoinTable({
+      name: 'follows',
+      joinColumn: {
+        name: 'follower_id',
+        referencedColumnName: 'id',
+      },
+      inverseJoinColumn: {
+        name: 'streamer_id',
+        referencedColumnName: 'id',
+      },
+    })
+    following: UserEntity[];
 }


### PR DESCRIPTION
## 📝 PR 설명
follow-api 생성했습니다.

### PR 메시지 고려 후 수정
1. 팔로우한 스트리머 목록을 조회하는 목적이지만, 스트리머 클릭 시 채널로 이동하는 것도 고려하고 있어서 join 사용은 불가피
  - 대신 완전 방송 목록은 아니라서 불필요한 category 하고 join 은 제외
  - 예시(수정 후)
  ```
  [
    {
      "categoriesId": 1,
      "categoriesName" : "카테고리 이름"
      "livesName": "방송 이름",
      "channelId" : "채널ID",
      "usersNickname" : "스트리머 닉네임",
      "usersProfileImage": "스트리머 프로필 이미지"
      "onAir":"현재 방송 상태"
    },
	  // 계속
  ]
  ```
  - 예시(수정 전)
  ```
  [
    {
      "channelId" : "채널ID",
      "usersNickname" : "스트리머 닉네임",
      "usersProfileImage": "스트리머 프로필 이미지"
      "onAir":"현재 방송 상태"
    },
	  // 실제
    {
      "channelId": "7a4c0afc-26ca-470e-9655-37cfcbdc1126",
      "usersNickname": "구글닉네임",
      "usersProfileImage": "https://kr.object.ncloudstorage.com/lico.image/profile-images/1731599665735-zoom_%C3%A1%C2%84%C2%86%C3%A1%C2%85%C2%A6%C3%A1%C2%86%C2%B7%C3%A1%C2%84%C2%87%C3%A1%C2%85%C2%A5%C3%A1%C2%84%C2%89%C3%A1%C2%85%C2%B5%C3%A1%C2%86%C2%B8_%C3%A1%C2%84%C2%87%C3%A1%C2%85%C2%A2%C3%A1%C2%84%C2%80%C3%A1%C2%85%C2%A7%C3%A1%C2%86%C2%BC.png",
      "onAir": false
    }
    // 계속 이어서
  ]
  ```

2. 경로로 팔로우 수정 

## ✅ 주요 변경 사항
- [ ] userEntity 에  following 프로퍼티가 리스트 형식으로 추가되었습니다.
- [ ] follow 모듈을 생성했습니다.

## 📸 스크린샷 (선택)

### 스티리머 팔로우
![경로_팔로우](https://github.com/user-attachments/assets/b31bb0e0-d156-4cc1-904f-d85a81e92e73)


### 스트리머 조회(방송 목록 처럼)
![스트리머 조회](https://github.com/user-attachments/assets/f870c900-853f-4c90-be4a-4b6706bb80b5)




### 스트리머 언팔로우
![경로_언팔로우](https://github.com/user-attachments/assets/d3152f5a-69f2-4d19-b2ee-31fb804bac50)
조회


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #이슈번호
- resolves #이슈번호

