### PR TITLE
[Feature] 라이브 갱신 필요 정보 획득 API 추가

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -13,6 +13,8 @@ import { ChatsModule } from './chats/chats.module';
 import { FollowModule } from './follow/follow.module';
 import sqliteConfig from './config/sqlite.config';
 import mysqlConfig from './config/mysql.config';
+import { RedisModule } from '@nestjs-modules/ioredis';
+import { redisConfig } from './config/redis.config';
 
 @Module({
   imports: [
@@ -24,6 +26,11 @@ import mysqlConfig from './config/mysql.config';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: async (configService: ConfigService) => typeOrmConfig(configService),
+    }),
+    RedisModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => redisConfig(configService),
     }),
     AuthModule,
     UsersModule,

--- a/Backend/src/chats/chats.module.ts
+++ b/Backend/src/chats/chats.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { redisConfig } from 'src/config/redis.config';
 import { ChatsGateway } from './chats.gateway';
 import { ChatsService } from './chats.service';
 import { RedisModule } from '@nestjs-modules/ioredis';
@@ -9,12 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 
 @Module({
   imports: [
-    RedisModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: async (configService: ConfigService) => redisConfig(configService),
-    }),
-
+    RedisModule,
     UsersModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],

--- a/Backend/src/config/redis.config.ts
+++ b/Backend/src/config/redis.config.ts
@@ -1,4 +1,3 @@
-// src/config/redis.config.ts
 import { RedisModuleOptions } from '@nestjs-modules/ioredis';
 import { ConfigService } from '@nestjs/config';
 

--- a/Backend/src/lives/dto/live.dto.ts
+++ b/Backend/src/lives/dto/live.dto.ts
@@ -1,10 +1,11 @@
 export class LiveDto {
-  readonly livesName: string;
-  readonly livesDescription: string;
+  readonly livesName: string | null;
+  readonly livesDescription: string | null;
   readonly startedAt: Date;
   readonly usersNickname: string;
   readonly usersProfileImage: string;
   readonly categoriesId: number | null;
   readonly categoriesName: string | null;
   readonly onAir: boolean | null;
+  readonly viewers: number;
 }

--- a/Backend/src/lives/dto/lives.dto.ts
+++ b/Backend/src/lives/dto/lives.dto.ts
@@ -1,9 +1,10 @@
 export class LivesDto {
   readonly channelId: string;
-  readonly livesName: string;
+  readonly livesName: string | null;
   readonly usersNickname: string;
   readonly usersProfileImage: string;
   readonly categoriesId: number | null;
   readonly categoriesName: string | null;
   readonly onAir: boolean | null;
+  readonly viewers: number;
 }

--- a/Backend/src/lives/dto/status.dto.ts
+++ b/Backend/src/lives/dto/status.dto.ts
@@ -1,6 +1,6 @@
 export class StatusDto {
-  readonly livesName: string;
-  readonly livesDescription: string;
+  readonly livesName: string | null;
+  readonly livesDescription: string | null;
   readonly categoriesId: number | null;
   readonly categoriesName: string | null;
   readonly onAir: boolean | null;

--- a/Backend/src/lives/dto/status.dto.ts
+++ b/Backend/src/lives/dto/status.dto.ts
@@ -1,0 +1,8 @@
+export class StatusDto {
+  readonly livesName: string;
+  readonly livesDescription: string;
+  readonly categoriesId: number | null;
+  readonly categoriesName: string | null;
+  readonly onAir: boolean | null;
+  readonly viewers: number;
+}

--- a/Backend/src/lives/dto/update.live.dto.ts
+++ b/Backend/src/lives/dto/update.live.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, isNotEmpty, IsNumber, IsString, MaxLength, Min, MIN } from 'class-validator';
+import { IsNumber, IsString, MaxLength, Min } from 'class-validator';
 
 export class UpdateLiveDto {
   @IsString()

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -13,6 +13,7 @@ import {
 } from 'typeorm';
 import { LivesDto } from '../dto/lives.dto';
 import { LiveDto } from '../dto/live.dto';
+import { StatusDto } from '../dto/status.dto';
 
 @Entity('lives')
 export class LiveEntity {
@@ -54,7 +55,7 @@ export class LiveEntity {
   deletedAt: Date | null;
 
   @Column({ name: 'viewers', type: 'int', default: 0 })
-  viewers: Number;
+  viewers: number;
 
   @OneToOne(() => UserEntity, user => user.live)
   user: UserEntity;
@@ -81,6 +82,17 @@ export class LiveEntity {
       usersNickname: this.user.nickname,
       usersProfileImage: this.user.profileImage,
       onAir: this.onAir,
+    };
+  }
+
+  toStatus(): StatusDto {
+    return {
+      categoriesId: this.category?.id,
+      categoriesName: this.category?.name,
+      livesName: this.name,
+      livesDescription: this.description,
+      onAir: this.onAir,
+      viewers: this.viewers,
     };
   }
 }

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -53,6 +53,9 @@ export class LiveEntity {
   @DeleteDateColumn({ name: 'deleted_at', nullable: true })
   deletedAt: Date | null;
 
+  @Column({ name: 'viewers', type: 'int', default: 0 })
+  viewers: Number;
+
   @OneToOne(() => UserEntity, user => user.live)
   user: UserEntity;
 

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -69,6 +69,7 @@ export class LiveEntity {
       usersNickname: this.user.nickname,
       usersProfileImage: this.user.profileImage,
       onAir: this.onAir,
+      viewers: this.viewers,
     };
   }
 
@@ -82,6 +83,7 @@ export class LiveEntity {
       usersNickname: this.user.nickname,
       usersProfileImage: this.user.profileImage,
       onAir: this.onAir,
+      viewers: this.viewers,
     };
   }
 

--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -18,6 +18,7 @@ import { UpdateLiveDto } from './dto/update.live.dto';
 import { UUID } from 'crypto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { UserEntity } from 'src/users/entity/user.entity';
+import { StatusDto } from './dto/status.dto';
 
 @Controller('lives')
 export class LivesController {
@@ -61,5 +62,10 @@ export class LivesController {
   @HttpCode(202)
   async endLive(@Param('channelId') channelId: UUID) {
     this.livesService.endLive(channelId);
+  }
+
+  @Get('/status/:channelId')
+  async getStatus(@Param('channelId') channelId: UUID): Promise<StatusDto> {
+    return await this.livesService.readStatus(channelId);
   }
 }

--- a/Backend/src/lives/lives.module.ts
+++ b/Backend/src/lives/lives.module.ts
@@ -4,9 +4,10 @@ import { LivesController } from './lives.controller';
 import { LiveEntity } from './entity/live.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ChatsModule } from 'src/chats/chats.module';
+import { RedisModule } from '@nestjs-modules/ioredis';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LiveEntity]), ChatsModule],
+  imports: [TypeOrmModule.forFeature([LiveEntity]), ChatsModule, RedisModule],
   providers: [LivesService],
   controllers: [LivesController],
   exports: [LivesService],

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -7,13 +7,30 @@ import { LiveDto } from './dto/live.dto';
 import { UUID } from 'crypto';
 import { ErrorMessage } from './error/error.message.enum';
 import { ChatsService } from './../chats/chats.service';
+import Redis from 'ioredis';
+import { UpdateLiveDto } from './dto/update.live.dto';
+import { InjectRedis } from '@nestjs-modules/ioredis';
 
 @Injectable()
 export class LivesService {
   constructor(
     @InjectRepository(LiveEntity) private livesRepository: Repository<LiveEntity>,
     private chatsService: ChatsService,
-  ) {}
+    @InjectRedis() private redisClient: Redis,
+  ) {
+    this.redisClient.config('SET', 'notify-keyspace-events', 'Ex');
+    this.redisClient.subscribe('__keyevent@0__:expired');
+
+    this.redisClient.on('message', async (channel, key) => {
+      const { channelId } = key.match(
+        /(?<channelId>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}):status/,
+      ).groups;
+
+      if (channelId) {
+        this.updateViewers(channelId as UUID);
+      }
+    });
+  }
 
   async readLives(where: FindOptionsWhere<LiveEntity> = {}): Promise<LivesDto[]> {
     // TODO 데이터 베이스 뷰 추가
@@ -34,9 +51,13 @@ export class LivesService {
     return live.toLiveDto();
   }
 
-  async updateLive({ channelId, updateLiveDto }) {
+  async updateLive({ channelId, updateLiveDto }: { channelId: UUID; updateLiveDto: UpdateLiveDto }) {
     // TODO 요청자와 채널 소유자 일치여부 체크(로그인 기능 구현 후)
     await this.livesRepository.update({ channelId }, updateLiveDto);
+  }
+
+  async updateViewers(channelId: UUID) {
+    await this.livesRepository.update({ channelId }, { viewers: await this.chatsService.readViewers(channelId) });
   }
 
   async readChannelId(streamingKey: UUID) {
@@ -57,7 +78,6 @@ export class LivesService {
 
   async endLive(channelId: UUID) {
     this.livesRepository.update({ channelId }, { onAir: false });
-    this.chatsService.clearChat(channelId);
   }
 
   async readStreamingKey(livesId: number) {

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -94,7 +94,7 @@ export class LivesService {
       return JSON.parse(cache);
     }
 
-    const live = await this.livesRepository.findOne({ where: { channelId } });
+    const live = await this.livesRepository.findOne({ relations: ['category'], where: { channelId } });
 
     if (!live) {
       throw new NotFoundException(ErrorMessage.LIVE_NOT_FOUND);

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -18,8 +18,8 @@ export class LivesService {
     private chatsService: ChatsService,
     @InjectRedis() private redisClient: Redis,
   ) {
+    this.redisClient.flushall();
     this.redisClient.config('SET', 'notify-keyspace-events', 'Ex');
-
     const subscriber = this.redisClient.duplicate();
     subscriber.subscribe('__keyevent@0__:expired');
 

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -64,6 +64,11 @@ export class LivesService {
 
   async readChannelId(streamingKey: UUID) {
     const live = await this.livesRepository.findOne({ where: { streamingKey } });
+
+    if (!live) {
+      throw new NotFoundException(ErrorMessage.LIVE_NOT_FOUND);
+    }
+
     return { channelId: live.channelId };
   }
 
@@ -80,11 +85,6 @@ export class LivesService {
 
   async endLive(channelId: UUID) {
     this.livesRepository.update({ channelId }, { onAir: false });
-  }
-
-  async readStreamingKey(livesId: number) {
-    const live = await this.livesRepository.findOne({ where: { id: livesId } });
-    return live.streamingKey;
   }
 
   async readStatus(channelId: UUID) {


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
라이브 테이블에 시청자수 컬럼 추가 및 갱신 정보 획득이 가능한 API를 추가하였습니다.
시청자수 쓰기에 write-back 전략을 갱신 정보 획득에 read-through 전략을 사용하였습니다.


## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

- 시청자수 정보 라이브 테이블에 추가
- 라이브 정보 DTO들에 시청자수 정보 추가
- 채팅에 연결된 유저들 정보를 이용하여 시청자수 주기적인 쓰기 구현

## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->
![image](https://github.com/user-attachments/assets/6e998c7f-3cad-4dd8-935e-9adc96417350)


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #218 #216 

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->

- 테스트 추가
