### PR TITLE
[Feature] lives-api 파라미터 응답 추가

### DIFF
--- a/Backend/src/categories/categories.controller.ts
+++ b/Backend/src/categories/categories.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CategoriesDto } from './dto/categories.dto';
 import { CategoryDto } from './dto/category.dto';
@@ -22,7 +22,12 @@ export class CategoriesController {
   }
 
   @Get('/:categoriesId/lives')
-  async getOnAirLivesByCategory(@Param('categoriesId', ParseIntPipe) categoriesId: number) {
-    return await this.livesService.readLives({ categoriesId, onAir: true });
+  async getOnAirLivesByCategory(
+    @Param('categoriesId', ParseIntPipe) categoriesId: number,
+    @Query('sort') sort: 'latest' | 'viewers' | 'recommendation' = 'latest',
+    @Query('limit') limit: number = 20,
+    @Query('offset') offset: number = 0,
+  ) {
+    return await this.livesService.readLives({ sort, limit, offset, categoriesId, onAir: true });
   }
 }

--- a/Backend/src/lives/lives.controller.ts
+++ b/Backend/src/lives/lives.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   UseGuards,
   ValidationPipe,
+  Query
 } from '@nestjs/common';
 import { LivesService } from './lives.service';
 import { LivesDto } from './dto/lives.dto';
@@ -23,9 +24,13 @@ import { UserEntity } from 'src/users/entity/user.entity';
 export class LivesController {
   constructor(private readonly livesService: LivesService) {}
 
-  @Get()
-  async getOnAirLives(): Promise<LivesDto[]> {
-    return await this.livesService.readLives({ onAir: true });
+  @Get() // 새로운 live 요청
+  async getOnAirLives(
+    @Query('sort') sort: 'latest' | 'viewers' | 'recommendation' = 'latest',
+    @Query('limit') limit = 20,
+    @Query('offset') offset = 0,
+  ): Promise<LivesDto[]> {
+    return await this.livesService.readLives({ sort, limit, offset });
   }
 
   @Get('/streaming-key')

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -8,6 +8,16 @@ import { UUID } from 'crypto';
 import { ErrorMessage } from './error/error.message.enum';
 import { ChatsService } from './../chats/chats.service';
 
+// 인터페이스 추가
+export interface ReadLivesOptions {
+  sort?: 'latest' | 'viewers' | 'recommendation';
+  limit?: number;
+  offset?: number;
+  categoriesId?: number;
+  onAir?: boolean;
+}
+
+
 @Injectable()
 export class LivesService {
   constructor(
@@ -15,13 +25,41 @@ export class LivesService {
     private chatsService: ChatsService,
   ) {}
 
-  async readLives(where: FindOptionsWhere<LiveEntity> = {}): Promise<LivesDto[]> {
-    // TODO 데이터 베이스 뷰 추가
-    const lives = await this.livesRepository.find({
-      relations: ['category', 'user'],
-      where,
-    });
-    return lives.map(entity => entity.toLivesDto());
+  async readLives(options: ReadLivesOptions): Promise<LivesDto[]> {
+    const { sort = 'latest', limit = 20, offset = 0, categoriesId, onAir } = options;
+
+    const queryBuilder = this.livesRepository
+      .createQueryBuilder('live')
+      .leftJoinAndSelect('live.category', 'category')
+      .leftJoinAndSelect('live.user', 'user');
+
+    // 기본 onAir true 상태
+    if (typeof onAir === 'boolean') {
+      queryBuilder.andWhere('live.onAir = :onAir', { onAir });
+    }
+
+    // 카테고리 필터
+    if (categoriesId) {
+      queryBuilder.andWhere('live.categoriesId = :categoriesId', { categoriesId });
+    }
+
+    // 정렬 로직 추가
+    if (sort === 'recommendation') {
+      queryBuilder.orderBy('RAND()'); // 추천은 랜덤 정렬
+    } else if (sort === 'viewers') {
+      // viewers 정렬은 아직 구현 X
+    } else {
+      // 기본은 최신순
+      queryBuilder.orderBy('live.createdAt', 'DESC');
+    }
+
+    // 페이지네이션 적용
+    const lives = await queryBuilder
+      .skip(offset)
+      .take(limit)
+      .getMany();
+
+    return lives.map((entity) => entity.toLivesDto());
   }
 
   async readLive(channelId: string): Promise<LiveDto> {

--- a/Backend/src/lives/lives.service.ts
+++ b/Backend/src/lives/lives.service.ts
@@ -26,7 +26,7 @@ export class LivesService {
   ) {}
 
   async readLives(options: ReadLivesOptions): Promise<LivesDto[]> {
-    const { sort = 'latest', limit = 20, offset = 0, categoriesId, onAir } = options;
+    const { sort = 'latest', limit = 20, offset = 0, categoriesId, onAir = true } = options;
 
     const queryBuilder = this.livesRepository
       .createQueryBuilder('live')


### PR DESCRIPTION
## 📝 PR 설명
인기, 추천, 최신순 그리고 무한스크롤을 지원하기 위해서 lives-api 에 파라미터 응답 추가했습니다.

참고: 아마도 이 PR 은 앞에 국희님 PR 하고 충돌이 날 수 있을 거 같습니다. 충돌 처리하기 어려울 경우, close 하고 다시 작성하는 것이 좋을 거 같습니다. 인기순 기능 때문에 어차피 다시 코드를 살펴봐야할 거 같기 때문입니다.

## ✅ 주요 변경 사항
- [ ] `lives` 엔드포인트에 쿼리 파라미터를 받을 수 있게 수정
- [ ] categories.controller 의 getOnAirLivesByCategory 가 쿼리 파라미터를 받을 수 있게 수정. this.livesService.readLives 를 사용하기 때문에 맞추다 보니 변경.

## 📸 스크린샷 (선택)
### `/live` 요청
첫 번째 요청:

```
GET http://localhost:3000/lives
```
```
기본값: sort=latest, limit=20, offset=0
```
![lives_요청비교](https://github.com/user-attachments/assets/bf418907-ece4-4bd2-a81a-eb87ec4a3310)

두 번째 요청:
```
GET http://localhost:3000/lives?sort=latest&limit=20&offset=20
```
![lives_2번](https://github.com/user-attachments/assets/69060fb4-7a10-43c7-8734-d1c7f21ae294)


세 번째 요청:
```
GET http://localhost:3000/lives?sort=latest&limit=20&offset=40
```
![lives_3번](https://github.com/user-attachments/assets/27c084fb-7341-4107-af84-dedee0de6aea)

### `/categories/{categoriesId}/lives` 요청
기본 요청
```
http://localhost:3000/categories/1/lives
```
![category_기본요청](https://github.com/user-attachments/assets/5999a8c0-249f-444d-b182-36e88ca292ce)


파라미터 추가
```
http://localhost:3000/categories/1/lives?sort=latest&limit=20&offset=0
```
![category_파라미터요청](https://github.com/user-attachments/assets/ab11f947-7ea7-4a64-8b9b-cdc1bc97e691)


## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)
- 시청자 수 조회 기반으로 인기 파라미터를 완성하기
