### PR TITLE
[Fix] : 라이브 상세 정보 조회에 streamerId를 추가

### DIFF
--- a/Backend/src/lives/dto/live.dto.ts
+++ b/Backend/src/lives/dto/live.dto.ts
@@ -8,4 +8,5 @@ export class LiveDto {
   readonly categoriesName: string | null;
   readonly onAir: boolean | null;
   readonly viewers: number;
+  readonly streamerId: number;
 }

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -84,6 +84,7 @@ export class LiveEntity {
       usersProfileImage: this.user.profileImage,
       onAir: this.onAir,
       viewers: this.viewers,
+      streamerId: this.user.id,
     };
   }
 


### PR DESCRIPTION
## 📝 PR 설명
팔로우 기능을 구현하기 위해서 **라이브 방송 상세 정보 조회**(  **엔드포인트:** `GET /lives/{channelId}`) 을 보낼 때, 데이터에 streamerId 가 있어야해서 dto 하고 엔티티에 streamerId를 추가했습니다. 

## ✅ 주요 변경 사항
- [ ] live.dto 에 streamerId 추가
- [ ] live.entity 의 LiveDto 에 streamerId 추가

## 📸 스크린샷 (선택)

## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)
