### PR TITLE
[Fix] lives 에도 streamerId 추가

### DIFF
--- a/Backend/src/lives/dto/lives.dto.ts
+++ b/Backend/src/lives/dto/lives.dto.ts
@@ -7,4 +7,5 @@ export class LivesDto {
   readonly categoriesName: string | null;
   readonly onAir: boolean | null;
   readonly viewers: number;
+  readonly streamerId: number;
 }

--- a/Backend/src/lives/entity/live.entity.ts
+++ b/Backend/src/lives/entity/live.entity.ts
@@ -70,6 +70,7 @@ export class LiveEntity {
       usersProfileImage: this.user.profileImage,
       onAir: this.onAir,
       viewers: this.viewers,
+      streamerId: this.user.id,
     };
   }
 


### PR DESCRIPTION
## 📝 PR 설명
프론트에드 요청에 따라서 방송 목록 조회에도 streamerId 추가합니다.

## ✅ 주요 변경 사항
- [ ] `lives` 에도 streamerId 데이터 추가

## 📸 스크린샷 (선택)

## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)

