### PR TITLE
[Fix] 채팅 연결 auth 수정

### DIFF
--- a/Frontend/src/components/chat/ChatWindow.tsx
+++ b/Frontend/src/components/chat/ChatWindow.tsx
@@ -131,9 +131,11 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
 
     const socket = io(`${config.apiBaseUrl}/chats`, {
       transports: ['websocket'],
-      auth: {
-        token: accessToken,
-      },
+      ...(isLoggedIn && {
+        auth: {
+          token: accessToken,
+        },
+      }),
     });
 
     socket.on('connect', () => {
@@ -148,7 +150,7 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
         socketRef.current = null;
       }
     };
-  }, [onAir, accessToken, id]);
+  }, [onAir, accessToken, id, isLoggedIn]);
 
   useEffect(() => {
     const socket = socketRef.current;


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
- 로그인일 때만 accessToken을 auth 옵션에 보내도록 했습니다.
- 비로그인일 경우 그냥 connect 하게 됩니다.
```js
    const socket = io(`${config.apiBaseUrl}/chats`, {
      transports: ['websocket'],
      ...(isLoggedIn && {
        auth: {
          token: accessToken,
        },
      }),
    });
```


## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

- [ ] 기능 1 추가/수정
- [ ] 버그 수정
- [ ] 문서 업데이트

## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #이슈번호
- resolves #이슈번호

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->

- [ ] 테스트 추가
- [ ] 코드 최적화
