### PR TITLE
[Config] 인코딩 설정 변경하여 CPU 부하 감소 및 인코딩 속도 증가

### DIFF
--- a/Backend/server/encoding/stream_process.sh
+++ b/Backend/server/encoding/stream_process.sh
@@ -23,17 +23,19 @@ if [[ -z "$CHANNEL_ID" ]]; then
     exit 1
 fi
 
-ffmpeg -rw_timeout 10000000 -r 30 -i "rtmp://192.168.1.6:1935/$APP_NAME/$STREAM_KEY" -y\
-    -map 0:v -map 0:a -c:a aac -b:a 128k -c:v libx264 -b:v:2 2800k -s:v:2 1280x720 -preset veryfast -g 30 -tune zerolatency -profile:v baseline \
-    -map 0:v -map 0:a -c:a aac -b:a 128k -c:v libx264 -b:v:1 1200k -s:v:1 854x480 -preset veryfast -g 30 -tune zerolatency -profile:v baseline \
-    -map 0:v -map 0:a -c:a aac -b:a 128k -c:v libx264 -b:v:0 600k -s:v:0 640x360 -preset veryfast -g 30 -tune zerolatency -profile:v baseline \
-    -keyint_min 30  -hls_time 1 -hls_segment_type fmp4 -hls_flags delete_segments+independent_segments+append_list -hls_list_size 3 -hls_delete_threshold 5 \
-    -hls_segment_filename "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/%03d.m4s" \
-    -master_pl_name "index.m3u8" \
-    -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2" \
-    -f hls "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/index.m3u8" \
-    -map 0:v -vf "fps=1/10" -update 1 -s 426x240 \
-    "/lico/storage/$APP_NAME/$CHANNEL_ID/thumbnail.png"
+ffmpeg -rw_timeout 10000000 -r 30 -i "rtmp://192.168.1.6:1935/$APP_NAME/$STREAM_KEY" \
+        -filter_complex "[0:v]split=3[720p][for480p][for360p];[for480p]scale=854:480[480p];[for360p]scale=640:360[360p]" \
+        -map "[720p]" -map 0:a -c:v:0 libx264 -b:v:0 2800k -s:v:0 1280x720 -preset ultrafast -g 30 -tune zerolatency -profile:v:0 baseline -c:a:0 aac -b:a:0 128k \
+        -map "[480p]" -map 0:a -c:v:1 libx264 -b:v:1 1200k -preset ultrafast -g 30 -tune zerolatency -profile:v:1 baseline -c:a:1 copy \
+        -map "[360p]" -map 0:a -c:v:2 libx264 -b:v:2 600k -preset ultrafast -g 30 -tune zerolatency -profile:v:2 baseline -c:a:2 copy \
+        -keyint_min 30 -hls_time 1 -hls_segment_type fmp4 -hls_flags delete_segments+independent_segments+append_list \
+        -hls_list_size 3 -hls_delete_threshold 5 \
+        -hls_segment_filename "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/%03d.m4s" \
+        -master_pl_name "index.m3u8" \
+        -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2" \
+        -f hls "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/index.m3u8" \
+        -map 0:v -vf "fps=1/10,scale=426:240" -update 1 "/lico/storage/$APP_NAME/$CHANNEL_ID/thumbnail.jpg"
+
 
 
 /lico/script/cleanup.sh "$APP_NAME" "$CHANNEL_ID"


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
ffmpeg 프리셋을 다시 ultrafast로 변경하여 cpu부하 감소 및 인코딩 속도 증가
기존 원본 스트림에 대하여 해상도 별로 인코딩작업을 수행하던 것을 720p 생성 시에만 수행하고 480p와 360p는 split 필터를 이용해 720p 스트림을 기반으로 스케일링하여 생성 오디오도 720p 생성 시에만 인코딩하고 나머지 해상도에서는 인코딩된 오디오를 복사
썸네일 생성 시에도 인코딩하지않고 스케일링만 수행하여 썸네일 생성, 썸네일 형식 jpg로 변경


## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

- 인코딩 옵션 변경
- 썸네일 파일 형식 변경

## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->
![image](https://github.com/user-attachments/assets/ec6d047e-bc06-4902-8bcb-e7d059ea9430)
단일 방송 송출 시의 CPU 부하가 30% 밑으로까지 내려감
