### PR TITLE
[Refactor] 채팅 리스트 리사이즈 함수 제거

### DIFF
--- a/Backend/src/chats/chats.gateway.ts
+++ b/Backend/src/chats/chats.gateway.ts
@@ -21,7 +21,6 @@ export class ChatsGateway implements OnGatewayDisconnect, OnGatewayConnection {
   @WebSocketServer()
   server: Server;
 
-  private readonly OLD_CHATS_RESIZE_TRIGGER = 100;
   private readonly OLD_CHATS_MAXIMUM_SIZE = 50;
 
   constructor(
@@ -40,8 +39,6 @@ export class ChatsGateway implements OnGatewayDisconnect, OnGatewayConnection {
 
     const oldChats = await this.redisClient.lrange(redisKey, -this.OLD_CHATS_MAXIMUM_SIZE, -1);
     socket.emit('chat', oldChats);
-
-    this.resizeOldChats(redisKey);
   }
 
   @SubscribeMessage('chat')
@@ -98,13 +95,6 @@ export class ChatsGateway implements OnGatewayDisconnect, OnGatewayConnection {
 
     if (parseInt(count) <= 0) {
       this.redisClient.hdel(redisKey, user.id);
-    }
-  }
-
-  async resizeOldChats(redisKey: string) {
-    const currentSize = await this.redisClient.llen(redisKey);
-    if (currentSize >= this.OLD_CHATS_RESIZE_TRIGGER) {
-      this.redisClient.ltrim(redisKey, -this.OLD_CHATS_MAXIMUM_SIZE, -1);
     }
   }
 }


### PR DESCRIPTION
📝 PR 설명
채팅 코드에서 채팅 리스트 크기를 매직넘버에서 상수로 변경하였습니다.
저장한 채팅 리스트 리사이즈 함수를 제거하였습니다.

✅ 주요 변경 사항
채팅 리스트 리사이즈 함수 삭제
채팅 리스트 최대 사이즈 상수화