### PR TITLE
[Feature] 카테고리 api 시청자 수, 방송 수 추가

### DIFF
--- a/Backend/src/categories/categories.service.ts
+++ b/Backend/src/categories/categories.service.ts
@@ -5,22 +5,44 @@ import { Repository } from 'typeorm';
 import { CategoriesDto } from './dto/categories.dto';
 import { CategoryDto } from './dto/category.dto';
 import { ErrorMessage } from './error/error.message.enum';
+import { LivesService } from '../lives/lives.service';
 
 @Injectable()
 export class CategoriesService {
-  constructor(@InjectRepository(CategoryEntity) private categoriesRepository: Repository<CategoryEntity>) {}
+  constructor(
+    @InjectRepository(CategoryEntity) private categoriesRepository: Repository<CategoryEntity>,
+    private livesService: LivesService,
+  ) {}
 
+  // 모든 카테고리
   async readCategories(): Promise<CategoriesDto[]> {
     const categories = await this.categoriesRepository.find();
-    return categories.map(({ id, name, image }) => {
+    const stats = await this.livesService.getCategoryStats();
+
+    // 카테고리 ID를 키로 하는 맵 생성
+    const statsMap = new Map<number, { liveCount: number; viewerCount: number }>();
+    stats.forEach((stat) => {
+      statsMap.set(stat.categoriesId, {
+        liveCount: stat.liveCount,
+        viewerCount: stat.viewerCount,
+      });
+    });
+
+    // 각 카테고리에 통계 정보 매핑
+    return categories.map((category) => {
+      const stat = statsMap.get(category.id) || { liveCount: 0, viewerCount: 0 };
       return {
-        id,
-        name,
-        image,
+        id: category.id,
+        name: category.name,
+        image: category.image,
+        liveCount: stat.liveCount,
+        viewerCount: stat.viewerCount,
       };
     });
   }
 
+
+  // 특정 카테고리 정보와 통계 캐싱
   async readCategory(id: number): Promise<CategoryDto> {
     const category = await this.categoriesRepository.findOne({ where: { id } });
 
@@ -28,6 +50,14 @@ export class CategoriesService {
       throw new NotFoundException(ErrorMessage.CATEGORY_NOT_FOUND);
     }
 
-    return { name: category.name, image: category.image };
+    // 라이브 수와 시청자 수 가져오기
+    const { liveCount, viewerCount } = await this.livesService.getCategoryStatsById(id);
+
+    return {
+      name: category.name,
+      image: category.image,
+      liveCount,
+      viewerCount,
+    };
   }
 }

--- a/Backend/src/categories/dto/categories.dto.ts
+++ b/Backend/src/categories/dto/categories.dto.ts
@@ -2,4 +2,6 @@ export class CategoriesDto {
   readonly id: number;
   readonly name: string;
   readonly image: string;
+  readonly liveCount: number;
+  readonly viewerCount: number;
 }

--- a/Backend/src/categories/dto/category.dto.ts
+++ b/Backend/src/categories/dto/category.dto.ts
@@ -1,4 +1,6 @@
 export class CategoryDto {
   readonly name: string;
   readonly image: string;
+  readonly liveCount: number;
+  readonly viewerCount: number;
 }


### PR DESCRIPTION
## 📝 PR 설명
카테고리 api 시청자 수, 방송 수 추가를 구현했습니다. 원래 redis 를 활용한 캐시 전략을 적용해 보려고 했지만, 캐시의 키가 Redis에서 만료될 때, 에러가 나와서 철회했습니다. typeORM 에서 지원하는 캐시 기능도 오히려 응답 속도가 느려서 단순하게 집계 쿼리로 구현했습니다.

## ✅ 주요 변경 사항
- [ ] `/categories` 시 `liveCount`, `viewerCount` 가 제공
- [ ] `/categories` 시 `liveCount`, `viewerCount` 가 제공


## 📸 스크린샷 (선택)
###  `/categories` 요청
![전체카테고리](https://github.com/user-attachments/assets/2d33c30f-1e5a-40f2-af4b-35011763672b)

### `/categories` 요청
![image](https://github.com/user-attachments/assets/14f36859-8c22-40a8-bc65-2be911b498a2)

## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)

