### PR TITLE
[Test] auth, users, follow, categories 테스트 코드 수정

### DIFF
--- a/Backend/src/auth/auth.controller.spec.ts
+++ b/Backend/src/auth/auth.controller.spec.ts
@@ -1,104 +1,386 @@
-// src/auth/auth.controller.spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
-import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
-import { ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException } from '@nestjs/common';
 import { Request, Response } from 'express';
 
-jest.mock('@nestjs/passport', () => ({
-  AuthGuard: () => {
-    return class MockAuthGuard {
-      canActivate(context: ExecutionContext) {
-        return true;
-      }
-    };
-  },
-}));
+// auth.controller.1.1. 필요한 메서드만 포함하는 커스텀 MockResponse 타입 정의
+type MockResponse = Partial<Response> & {
+  cookie: jest.Mock;
+  json: jest.Mock;
+  status: jest.Mock;
+};
+
+// auth.controller.1.2. mockResponse 함수 정의
+const mockResponse = (): MockResponse => ({
+  cookie: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+  status: jest.fn().mockReturnThis(),
+});
+
+// auth.controller.1.3. console.error를 모킹하여 테스트 중 에러 로그 숨기기
+beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
 
 describe('AuthController', () => {
   let controller: AuthController;
-  let configService: ConfigService;
   let authService: AuthService;
+  let configService: ConfigService;
 
+  // auth.controller.2.1. Mock AuthService 정의
+  const mockAuthService = {
+    validateOAuthLogin: jest.fn(),
+    refreshTokens: jest.fn(),
+  };
+
+  // auth.controller.2.2. Mock ConfigService 정의
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  // auth.controller.2.3. TestingModule 설정 및 의존성 주입
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
-        ConfigService,
-        {
-          provide: AuthService,
-          useValue: {}, // 필요한 경우 AuthService를 모의로 제공
-        },
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
-    configService = module.get<ConfigService>(ConfigService);
     authService = module.get<AuthService>(AuthService);
+    configService = module.get<ConfigService>(ConfigService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  // auth.controller.2.4. 각 테스트 후 Mock 함수 초기화
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  describe('OAuth 로그인 엔드포인트', () => {
-    it('should have githubAuth method', () => {
-      expect(controller.githubAuth).toBeDefined();
-    });
+  // auth.controller.3. OAuth Callback Endpoints 테스트 스위트 시작
+  describe('OAuth Callback Endpoints', () => {
+    // auth.controller.3.1.1. Mock 요청 객체 생성 함수 정의
+    const mockRequest = (user: any) => ({
+      user,
+    }) as Request & { user: any };
 
-    it('should have googleAuth method', () => {
-      expect(controller.googleAuth).toBeDefined();
-    });
-
-    it('should have naverAuth method', () => {
-      expect(controller.naverAuth).toBeDefined();
-    });
-  });
-
-  describe('OAuth 콜백 엔드포인트', () => {
-    it('should have githubAuthCallback method', () => {
-      expect(controller.githubAuthCallback).toBeDefined();
-    });
-
-    it('should have googleAuthCallback method', () => {
-      expect(controller.googleAuthCallback).toBeDefined();
-    });
-
-    it('should have naverAuthCallback method', () => {
-      expect(controller.naverAuthCallback).toBeDefined();
-    });
-  });
-
-  describe('handleAuthCallback', () => {
-    it('should set cookie and redirect', () => {
-      const req = {
-        user: {
-          jwt: 'test-jwt-token',
-        },
-      } as Request & { user: any };
-
-      const res = {
-        cookie: jest.fn(),
-        redirect: jest.fn(),
-      } as unknown as Response;
-
-      jest.spyOn(configService, 'get').mockImplementation((key: string) => {
-        if (key === 'CLIENT_URL') {
-          return 'http://localhost:3000';
-        }
+    // auth.controller.3.1.2. OAuth 콜백 핸들링 함수 정의 (테스트 재사용을 위해)
+    const handleOAuthCallback = async (
+      provider: string,
+      user: any,
+      expectedRedirectUrl: string,
+    ) => {
+      // ConfigService의 get 메서드 모킹
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'IS_PRODUCTION') return 'false';
+        if (key === 'CLIENT_URL') return expectedRedirectUrl;
         return null;
       });
 
-      controller['handleAuthCallback'](req, res);
+      // AuthService의 validateOAuthLogin 메서드 모킹
+      mockAuthService.validateOAuthLogin.mockResolvedValue({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        user: {
+          id: user.id,
+          nickname: user.nickname,
+          profileImage: user.profileImage,
+          channelId: null,
+          liveId: null,
+        },
+      });
 
-      expect(res.cookie).toHaveBeenCalledWith('jwt', 'test-jwt-token', {
+      // Mock 요청 및 응답 객체 생성
+      const req = mockRequest(user);
+      const res = mockResponse();
+
+      // 동적으로 적절한 콜백 메서드 호출
+      if (provider === 'google') {
+        await controller.googleAuthCallback(req, res as unknown as Response);
+      } else if (provider === 'github') {
+        await controller.githubAuthCallback(req, res as unknown as Response);
+      } else if (provider === 'naver') {
+        await controller.naverAuthCallback(req, res as unknown as Response);
+      }
+
+      // AuthService.validateOAuthLogin 호출 검증
+      expect(authService.validateOAuthLogin).toHaveBeenCalledWith(
+        user.oauthUid,
+        user.provider,
+        {
+          nickname: user.nickname,
+          profileImage: user.profileImage,
+          email: user.email,
+        },
+      );
+
+      // res.cookie 호출 검증
+      expect(res.cookie).toHaveBeenCalledWith('refreshToken', 'refresh-token', {
         httpOnly: true,
         secure: false,
-        maxAge: 36000000,
         sameSite: 'lax',
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+        domain: '.lico.digital',
+        path: '/',
       });
-      expect(res.redirect).toHaveBeenCalledWith('http://localhost:3000');
+
+      // res.json 호출 검증
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        accessToken: 'access-token',
+        user: {
+          id: user.id,
+          nickname: user.nickname,
+          profileImage: user.profileImage,
+          channelId: null,
+          liveId: null,
+        },
+      });
+    };
+
+    // auth.controller.3.2.1. Google OAuth 콜백 핸들링 테스트
+    it('should handle Google OAuth callback correctly', async () => {
+      const user = {
+        oauthUid: 'google-oauth-uid',
+        provider: 'google',
+        nickname: 'GoogleUser',
+        profileImage: 'https://example.com/google-user.jpg',
+        email: 'googleuser@example.com',
+      };
+      const expectedRedirectUrl = 'http://localhost:3000';
+      await handleOAuthCallback('google', user, expectedRedirectUrl);
+    });
+
+    // auth.controller.3.2.2. GitHub OAuth 콜백 핸들링 테스트
+    it('should handle GitHub OAuth callback correctly', async () => {
+      const user = {
+        oauthUid: 'github-oauth-uid',
+        provider: 'github',
+        nickname: 'GithubUser',
+        profileImage: 'https://example.com/github-user.jpg',
+        email: 'githubuser@example.com',
+      };
+      const expectedRedirectUrl = 'http://localhost:3000';
+      await handleOAuthCallback('github', user, expectedRedirectUrl);
+    });
+
+    // auth.controller.3.2.3. Naver OAuth 콜백 핸들링 테스트
+    it('should handle Naver OAuth callback correctly', async () => {
+      const user = {
+        oauthUid: 'naver-oauth-uid',
+        provider: 'naver',
+        nickname: 'NaverUser',
+        profileImage: 'https://example.com/naver-user.jpg',
+        email: 'naveruser@example.com',
+      };
+      const expectedRedirectUrl = 'http://localhost:3000';
+      await handleOAuthCallback('naver', user, expectedRedirectUrl);
+    });
+
+    // auth.controller.3.2.4. OAuth 콜백 실패 처리 테스트
+    it('should handle OAuth callback failure', async () => {
+      // ConfigService의 get 메서드 모킹
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'IS_PRODUCTION') return 'false';
+        if (key === 'CLIENT_URL') return 'http://localhost:3000';
+        return null;
+      });
+
+      // AuthService.validateOAuthLogin가 UnauthorizedException을 던지도록 모킹
+      mockAuthService.validateOAuthLogin.mockRejectedValue(
+        new UnauthorizedException('OAuth 인증 실패'),
+      );
+
+      // user가 null인 경우의 요청 및 응답 객체 생성
+      const req = mockRequest(null); // user가 null인 경우
+      const res = mockResponse();
+
+      // Google OAuth 콜백 메서드 호출
+      await controller.googleAuthCallback(req, res as unknown as Response);
+
+      // AuthService.validateOAuthLogin가 호출되지 않았는지 검증
+      expect(authService.validateOAuthLogin).not.toHaveBeenCalled();
+
+      // res.status 호출 검증
+      expect(res.status).toHaveBeenCalledWith(401);
+
+      // res.json 호출 검증
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: 'OAuth 인증 실패',
+      });
+    });
+  });
+
+  // auth.controller.4. Logout Endpoint 테스트 스위트 시작
+  describe('Logout Endpoint', () => {
+    // auth.controller.4.1.1. 정상적인 로그아웃 처리 테스트
+    it('should clear refreshToken cookie and respond with success', async () => {
+      mockConfigService.get.mockReturnValue('false'); // IS_PRODUCTION = false
+
+      const req = {} as Request;
+      const res = mockResponse();
+
+      // logout 메서드 호출
+      await controller.logout(req, res as unknown as Response);
+
+      // res.cookie 호출 검증
+      expect(res.cookie).toHaveBeenCalledWith('refreshToken', '', {
+        httpOnly: true,
+        secure: false,
+        sameSite: 'lax',
+        maxAge: 0,
+        domain: '.lico.digital',
+        path: '/',
+      });
+
+      // res.status 호출 검증
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      // res.json 호출 검증
+      expect(res.json).toHaveBeenCalledWith({ success: true });
+    });
+
+    // auth.controller.4.1.2. 로그아웃 실패 시 예외 처리 테스트
+    it('should handle logout failure gracefully', async () => {
+      mockConfigService.get.mockReturnValue('false'); // IS_PRODUCTION = false
+
+      const req = {} as Request;
+      const res = mockResponse();
+
+      // logout 중 에러를 발생시키도록 res.cookie 모킹
+      res.cookie.mockImplementation(() => {
+        throw new Error('Cookie Error');
+      });
+
+      // logout 메서드 호출
+      await controller.logout(req, res as unknown as Response);
+
+      // res.cookie 호출 검증
+      expect(res.cookie).toHaveBeenCalled();
+
+      // res.status 호출 검증
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      // res.json 호출 검증
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        message: '로그아웃에 실패했습니다.',
+      });
+    });
+  });
+
+  // auth.controller.5. Refresh Tokens Endpoint 테스트 스위트 시작
+  describe('Refresh Tokens Endpoint', () => {
+    // auth.controller.5.1.1. 정상적으로 토큰이 재발급되고 쿠키가 설정되는지 테스트
+    it('should refresh tokens and set new refreshToken cookie', async () => {
+      const mockRefreshToken = 'existing-refresh-token';
+      const mockNewTokens = {
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        user: {
+          id: 1,
+          nickname: 'TestUser',
+          profileImage: 'https://example.com/test-user.jpg',
+          channelId: null,
+          liveId: null,
+        },
+      };
+
+      // AuthService.refreshTokens가 새로운 토큰을 반환하도록 모킹
+      mockAuthService.refreshTokens.mockResolvedValue(mockNewTokens);
+      mockConfigService.get.mockReturnValue('false'); // IS_PRODUCTION = false
+
+      // refresh 토큰이 포함된 요청 객체 생성
+      const req = {
+        cookies: {
+          refreshToken: mockRefreshToken,
+        },
+      } as unknown as Request;
+
+      const res = mockResponse();
+
+      // refresh 메서드 호출
+      await controller.refresh(req, res as unknown as Response);
+
+      // AuthService.refreshTokens 호출 검증
+      expect(authService.refreshTokens).toHaveBeenCalledWith(mockRefreshToken);
+
+      // res.cookie 호출 검증
+      expect(res.cookie).toHaveBeenCalledWith('refreshToken', 'new-refresh-token', {
+        httpOnly: true,
+        secure: false,
+        sameSite: 'lax',
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+        domain: '.lico.digital',
+        path: '/',
+      });
+
+      // res.status 호출 검증
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      // res.json 호출 검증
+      expect(res.json).toHaveBeenCalledWith({
+        accessToken: 'new-access-token',
+        user: {
+          id: 1,
+          nickname: 'TestUser',
+          profileImage: 'https://example.com/test-user.jpg',
+          channelId: null,
+          liveId: null,
+        },
+      });
+    });
+
+    // auth.controller.5.1.2. refresh 토큰이 없을 경우 UnauthorizedException을 던지는지 테스트
+    it('should throw UnauthorizedException if refresh token is missing', async () => {
+      const req = {
+        cookies: {},
+      } as unknown as Request;
+
+      const res = mockResponse();
+
+      // refresh 메서드가 UnauthorizedException을 던지는지 확인
+      await expect(controller.refresh(req, res as unknown as Response)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      // AuthService.refreshTokens가 호출되지 않았는지 확인
+      expect(authService.refreshTokens).not.toHaveBeenCalled();
+    });
+
+    // auth.controller.5.1.3. refresh 토큰이 유효하지 않을 경우 UnauthorizedException을 던지는지 테스트
+    it('should throw UnauthorizedException if refresh token is invalid', async () => {
+      const mockRefreshToken = 'invalid-refresh-token';
+
+      // AuthService.refreshTokens가 UnauthorizedException을 던지도록 모킹
+      mockAuthService.refreshTokens.mockRejectedValue(
+        new UnauthorizedException('Could not refresh tokens'),
+      );
+
+      // refresh 토큰이 포함된 요청 객체 생성
+      const req = {
+        cookies: {
+          refreshToken: mockRefreshToken,
+        },
+      } as unknown as Request;
+
+      const res = mockResponse();
+
+      // refresh 메서드가 UnauthorizedException을 던지는지 확인
+      await expect(controller.refresh(req, res as unknown as Response)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      // AuthService.refreshTokens 호출 검증
+      expect(authService.refreshTokens).toHaveBeenCalledWith(mockRefreshToken);
     });
   });
 });

--- a/Backend/src/auth/auth.service.spec.ts
+++ b/Backend/src/auth/auth.service.spec.ts
@@ -2,143 +2,395 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
-import { UserEntity } from '../users/entity/user.entity';
-import { LiveEntity } from '../lives/entity/live.entity';
-import { CategoryEntity } from '../categories/entity/category.entity';
+import { ConfigService } from '@nestjs/config';
+import { UnauthorizedException } from '@nestjs/common';
 
 describe('AuthService', () => {
   let service: AuthService;
   let usersService: UsersService;
   let jwtService: JwtService;
+  let configService: ConfigService;
 
-  // Mock CategoryEntity 정의
-  const mockCategoryEntity: CategoryEntity = {
-    id: 1,
-    name: 'Category Name',
-    image: 'http://example.com/category.jpg',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    lives: [],
-  } as CategoryEntity;
-
-  // Mock LiveEntity 정의
-  const mockLiveEntity: LiveEntity = {
-    id: 1,
-    categoriesId: 1,
-    category: mockCategoryEntity,
-    channelId: 'channel-123',
-    name: 'Live Name',
-    description: 'Live Description',
-    streamingKey: 'streaming-key-123',
-    onAir: true,
-    startedAt: new Date(),
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    deletedAt: null,
-    user: {} as UserEntity, // 순환 참조 방지를 위해 빈 객체로 설정
-
-    // LiveEntity의 메서드 추가
-    toLivesDto: jest.fn(),
-    toLiveDto: jest.fn(),
+  // auth.service.1.1. Mock UsersService 정의
+  const mockUsersService = {
+    findByOAuthUid: jest.fn(),
+    createUser: jest.fn(),
+    findById: jest.fn(),
   };
 
-  function createMockUserEntity(overrides?: Partial<UserEntity>): UserEntity {
-    return {
-      id: 1,
-      oauthUid: 'oauth-uid',
-      oauthPlatform: 'github',
-      nickname: 'testuser',
-      profileImage: 'http://example.com/profile.jpg',
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      deletedAt: null,
-      live: mockLiveEntity, // live 프로퍼티 추가
-      ...overrides,
-    };
-  }
+  // auth.service.1.2. Mock JwtService 정의
+  const mockJwtService = {
+    signAsync: jest.fn(),
+    verifyAsync: jest.fn(),
+  };
 
+  // auth.service.1.3. Mock ConfigService 정의
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  // auth.service.1.4. console.error를 모킹하여 테스트 중 에러 로그 숨기기
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  // auth.service.1.5. 모든 테스트 후 Mock 함수 복원
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  // auth.service.1.6. TestingModule 설정 및 의존성 주입
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
-        {
-          provide: UsersService,
-          useValue: {
-            findByOAuthUid: jest.fn(),
-            createUser: jest.fn(),
-          },
-        },
-        {
-          provide: JwtService,
-          useValue: {
-            sign: jest.fn().mockReturnValue('test-jwt-token'),
-          },
-        },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
     usersService = module.get<UsersService>(UsersService);
     jwtService = module.get<JwtService>(JwtService);
+    configService = module.get<ConfigService>(ConfigService);
   });
 
+  // auth.service.1.7. 각 테스트 후 Mock 함수 초기화
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // auth.service.2.1. 서비스가 제대로 정의되었는지 확인하는 기본 테스트
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
+  // auth.service.3. validateOAuthLogin 메서드에 대한 테스트 스위트 시작
   describe('validateOAuthLogin', () => {
-    const oauthUid = 'oauth-uid';
-    const oauthPlatform = 'github';
+    const oauthUid = 'test-oauth-uid';
+    const oauthPlatform: 'google' | 'github' | 'naver' = 'github';
     const profileData = {
-      username: 'testuser',
-      profileImage: 'http://example.com/profile.jpg',
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      email: 'testuser@example.com',
     };
 
-    it('should create a new user if not exists and return jwt', async () => {
-      // UsersService의 findByOAuthUid가 undefined 반환 (사용자 없음)
-      jest.spyOn(usersService, 'findByOAuthUid').mockResolvedValue(undefined);
+    // auth.service.3.1.1. Mock 사용자 데이터 정의 (live를 null로 설정)
+    const mockUser = {
+      id: 1,
+      oauthUid,
+      oauthPlatform,
+      nickname: profileData.nickname,
+      profileImage: profileData.profileImage,
+      live: null, // live를 null로 설정
+    };
 
-      // UsersService의 createUser가 새로운 사용자 반환
-      jest.spyOn(usersService, 'createUser').mockResolvedValue(
-        createMockUserEntity({
-          id: 1,
-          oauthUid,
-          oauthPlatform,
-          nickname: profileData.username,
-          profileImage: profileData.profileImage,
-        }),
+    // auth.service.3.1.2. JWT 페이로드 정의
+    const mockPayload = {
+      sub: {
+        id: mockUser.id,
+        provider: mockUser.oauthPlatform,
+      },
+    };
+
+    // auth.service.3.1.3. 사용자가 존재하지 않을 경우 새로운 사용자를 생성하고 토큰을 반환하는 테스트
+    it('should create a new user if not exists and return tokens with user data', async () => {
+      // UsersService.findByOAuthUid가 undefined를 반환하여 사용자가 존재하지 않음을 모킹
+      mockUsersService.findByOAuthUid.mockResolvedValue(undefined);
+
+      // UsersService.createUser가 새로운 사용자를 반환하도록 모킹
+      mockUsersService.createUser.mockResolvedValue(mockUser);
+
+      // JwtService.signAsync가 액세스 토큰과 리프레시 토큰을 반환하도록 모킹
+      mockJwtService.signAsync
+        .mockResolvedValueOnce('access-token') // accessToken
+        .mockResolvedValueOnce('refresh-token'); // refreshToken
+
+      // ConfigService.get이 JWT 시크릿을 반환하도록 모킹
+      mockConfigService.get.mockReturnValue('test-jwt-secret');
+
+      // validateOAuthLogin 메서드 호출
+      const result = await service.validateOAuthLogin(
+        oauthUid,
+        oauthPlatform,
+        profileData,
       );
 
-      const jwt = await service.validateOAuthLogin(oauthUid, oauthPlatform, profileData);
+      // UsersService.findByOAuthUid가 올바르게 호출되었는지 확인
+      expect(usersService.findByOAuthUid).toHaveBeenCalledWith(
+        oauthUid,
+        oauthPlatform,
+      );
 
-      expect(usersService.findByOAuthUid).toHaveBeenCalledWith(oauthUid, oauthPlatform);
+      // UsersService.createUser가 올바르게 호출되었는지 확인
       expect(usersService.createUser).toHaveBeenCalledWith({
         oauthUid,
         oauthPlatform,
-        nickname: profileData.username,
+        nickname: profileData.nickname,
         profileImage: profileData.profileImage,
       });
-      expect(jwt).toEqual('test-jwt-token');
-    });
 
-    it('should return jwt if user exists', async () => {
-      // UsersService의 findByOAuthUid가 기존 사용자 반환
-      jest.spyOn(usersService, 'findByOAuthUid').mockResolvedValue(
-        createMockUserEntity({
-          id: 1,
-          oauthUid,
-          oauthPlatform,
-          nickname: profileData.username,
-          profileImage: profileData.profileImage,
-        }),
+      // JwtService.signAsync가 올바른 페이로드와 옵션으로 호출되었는지 확인
+      expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+        1,
+        mockPayload,
+        { expiresIn: '1h' },
       );
 
-      const jwt = await service.validateOAuthLogin(oauthUid, oauthPlatform, profileData);
+      expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+        2,
+        { ...mockPayload, type: 'refresh' },
+        { expiresIn: '7d' },
+      );
 
-      expect(usersService.findByOAuthUid).toHaveBeenCalledWith(oauthUid, oauthPlatform);
+      // 반환된 결과가 예상과 일치하는지 확인
+      expect(result).toEqual({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        user: {
+          id: mockUser.id,
+          nickname: mockUser.nickname,
+          profileImage: mockUser.profileImage,
+          channelId: null, // live가 null이므로 channelId도 null
+          liveId: null,    // live가 null이므로 liveId도 null
+        },
+      });
+    });
+
+    // auth.service.3.1.4. 사용자가 이미 존재할 경우 토큰을 반환하는 테스트
+    it('should return tokens with user data if user already exists', async () => {
+      // UsersService.findByOAuthUid가 기존 사용자를 반환하도록 모킹
+      mockUsersService.findByOAuthUid.mockResolvedValue(mockUser);
+
+      // JwtService.signAsync가 액세스 토큰과 리프레시 토큰을 반환하도록 모킹
+      mockJwtService.signAsync
+        .mockResolvedValueOnce('access-token')
+        .mockResolvedValueOnce('refresh-token');
+
+      // ConfigService.get이 JWT 시크릿을 반환하도록 모킹
+      mockConfigService.get.mockReturnValue('test-jwt-secret');
+
+      // validateOAuthLogin 메서드 호출
+      const result = await service.validateOAuthLogin(
+        oauthUid,
+        oauthPlatform,
+        profileData,
+      );
+
+      // UsersService.findByOAuthUid가 올바르게 호출되었는지 확인
+      expect(usersService.findByOAuthUid).toHaveBeenCalledWith(
+        oauthUid,
+        oauthPlatform,
+      );
+
+      // UsersService.createUser가 호출되지 않았는지 확인
       expect(usersService.createUser).not.toHaveBeenCalled();
-      expect(jwt).toEqual('test-jwt-token');
+
+      // JwtService.signAsync가 올바른 페이로드와 옵션으로 호출되었는지 확인
+      expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+        1,
+        mockPayload,
+        { expiresIn: '1h' },
+      );
+
+      expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+        2,
+        { ...mockPayload, type: 'refresh' },
+        { expiresIn: '7d' },
+      );
+
+      // 반환된 결과가 예상과 일치하는지 확인
+      expect(result).toEqual({
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        user: {
+          id: mockUser.id,
+          nickname: mockUser.nickname,
+          profileImage: mockUser.profileImage,
+          channelId: null,
+          liveId: null,
+        },
+      });
+    });
+  });
+
+  // auth.service.4. refreshTokens 메서드에 대한 테스트 스위트 시작
+  describe('refreshTokens', () => {
+    const mockRefreshToken = 'existing-refresh-token';
+    const mockNewAccessToken = 'new-access-token';
+    const mockNewRefreshToken = 'new-refresh-token';
+    const mockPayload = {
+      sub: {
+        id: 1,
+        provider: 'github',
+      },
+      type: 'refresh',
+    };
+
+    // auth.service.4.1.1. Mock 사용자 데이터 정의 (live를 null로 설정)
+    const mockUser = {
+      id: 1,
+      oauthUid: 'test-oauth-uid',
+      oauthPlatform: 'github',
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      live: null, // live를 null로 설정
+    };
+
+    // auth.service.4.1.2. refreshTokens 메서드가 성공적으로 토큰을 재발급하는 테스트
+    it('should refresh tokens and return new tokens with user data', async () => {
+      // JwtService.verifyAsync가 유효한 페이로드를 반환하도록 모킹
+      mockJwtService.verifyAsync.mockResolvedValue(mockPayload);
+
+      // UsersService.findById가 기존 사용자를 반환하도록 모킹
+      mockUsersService.findById.mockResolvedValue(mockUser);
+
+      // JwtService.signAsync가 새로운 액세스 토큰과 리프레시 토큰을 반환하도록 모킹
+      mockJwtService.signAsync
+        .mockResolvedValueOnce(mockNewAccessToken) // new accessToken
+        .mockResolvedValueOnce(mockNewRefreshToken); // new refreshToken
+
+      // ConfigService.get이 JWT 시크릿을 반환하도록 모킹
+      mockConfigService.get.mockReturnValue('test-jwt-secret');
+
+      // refreshTokens 메서드 호출
+      const result = await service.refreshTokens(mockRefreshToken);
+
+      // JwtService.verifyAsync가 올바르게 호출되었는지 확인
+      expect(jwtService.verifyAsync).toHaveBeenCalledWith(mockRefreshToken, {
+        secret: 'test-jwt-secret', // 수정된 부분
+      });
+
+      // UsersService.findById가 올바르게 호출되었는지 확인
+      expect(usersService.findById).toHaveBeenCalledWith(1);
+
+      // JwtService.signAsync가 올바른 페이로드와 옵션으로 호출되었는지 확인
+      expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+        1,
+        {
+          sub: {
+            id: mockUser.id,
+            provider: mockUser.oauthPlatform,
+          },
+        },
+        { expiresIn: '1h' },
+      );
+
+      expect(jwtService.signAsync).toHaveBeenNthCalledWith(
+        2,
+        {
+          ...{
+            sub: {
+              id: mockUser.id,
+              provider: mockUser.oauthPlatform,
+            },
+          },
+          type: 'refresh',
+        },
+        { expiresIn: '7d' },
+      );
+
+      // 반환된 결과가 예상과 일치하는지 확인
+      expect(result).toEqual({
+        accessToken: mockNewAccessToken,
+        refreshToken: mockNewRefreshToken,
+        user: {
+          id: mockUser.id,
+          nickname: mockUser.nickname,
+          profileImage: mockUser.profileImage,
+          channelId: null, // live가 null이므로 channelId도 null
+          liveId: null,    // live가 null이므로 liveId도 null
+        },
+      });
+    });
+
+    // auth.service.4.1.3. refresh 토큰이 유효하지 않을 경우 UnauthorizedException을 던지는 테스트
+    it('should throw UnauthorizedException if refresh token is invalid', async () => {
+      // JwtService.verifyAsync가 에러를 던지도록 모킹
+      mockJwtService.verifyAsync.mockRejectedValue(
+        new Error('Invalid token'),
+      );
+
+      // ConfigService.get이 JWT 시크릿을 반환하도록 모킹
+      mockConfigService.get.mockReturnValue('test-jwt-secret');
+
+      // refreshTokens 메서드가 UnauthorizedException을 던지는지 확인
+      await expect(
+        service.refreshTokens(mockRefreshToken),
+      ).rejects.toThrow(UnauthorizedException);
+
+      // JwtService.verifyAsync가 올바르게 호출되었는지 확인
+      expect(jwtService.verifyAsync).toHaveBeenCalledWith(mockRefreshToken, {
+        secret: 'test-jwt-secret', // 수정된 부분
+      });
+
+      // UsersService.findById가 호출되지 않았는지 확인
+      expect(usersService.findById).not.toHaveBeenCalled();
+
+      // JwtService.signAsync가 호출되지 않았는지 확인
+      expect(jwtService.signAsync).not.toHaveBeenCalled();
+    });
+
+    // auth.service.4.1.4. refresh 토큰 타입이 'refresh'가 아닐 경우 UnauthorizedException을 던지는 테스트
+    it('should throw UnauthorizedException if refresh token type is not refresh', async () => {
+      const invalidPayload = {
+        sub: {
+          id: 1,
+          provider: 'github',
+        },
+        type: 'access', // invalid type
+      };
+
+      // JwtService.verifyAsync가 invalidPayload를 반환하도록 모킹
+      mockJwtService.verifyAsync.mockResolvedValue(invalidPayload);
+
+      // ConfigService.get이 JWT 시크릿을 반환하도록 모킹
+      mockConfigService.get.mockReturnValue('test-jwt-secret');
+
+      // refreshTokens 메서드가 UnauthorizedException을 던지는지 확인
+      await expect(
+        service.refreshTokens(mockRefreshToken),
+      ).rejects.toThrow(UnauthorizedException);
+
+      // JwtService.verifyAsync가 올바르게 호출되었는지 확인
+      expect(jwtService.verifyAsync).toHaveBeenCalledWith(mockRefreshToken, {
+        secret: 'test-jwt-secret', // 수정된 부분
+      });
+
+      // UsersService.findById가 호출되지 않았는지 확인
+      expect(usersService.findById).not.toHaveBeenCalled();
+
+      // JwtService.signAsync가 호출되지 않았는지 확인
+      expect(jwtService.signAsync).not.toHaveBeenCalled();
+    });
+
+    // auth.service.4.1.5. 사용자가 존재하지 않을 경우 UnauthorizedException을 던지는 테스트
+    it('should throw UnauthorizedException if user not found', async () => {
+      // JwtService.verifyAsync가 유효한 페이로드를 반환하도록 모킹
+      mockJwtService.verifyAsync.mockResolvedValue(mockPayload);
+
+      // UsersService.findById가 null을 반환하여 사용자가 존재하지 않음을 모킹
+      mockUsersService.findById.mockResolvedValue(null);
+
+      // ConfigService.get이 JWT 시크릿을 반환하도록 모킹
+      mockConfigService.get.mockReturnValue('test-jwt-secret');
+
+      // refreshTokens 메서드가 UnauthorizedException을 던지는지 확인
+      await expect(
+        service.refreshTokens(mockRefreshToken),
+      ).rejects.toThrow(UnauthorizedException);
+
+      // JwtService.verifyAsync가 올바르게 호출되었는지 확인
+      expect(jwtService.verifyAsync).toHaveBeenCalledWith(mockRefreshToken, {
+        secret: 'test-jwt-secret', // 수정된 부분
+      });
+
+      // UsersService.findById가 올바르게 호출되었는지 확인
+      expect(usersService.findById).toHaveBeenCalledWith(1);
+
+      // JwtService.signAsync가 호출되지 않았는지 확인
+      expect(jwtService.signAsync).not.toHaveBeenCalled();
     });
   });
 });

--- a/Backend/src/auth/auth.service.ts
+++ b/Backend/src/auth/auth.service.ts
@@ -52,8 +52,8 @@ export class AuthService {
         id: user.id,
         nickname: user.nickname,
         profileImage: user.profileImage,
-        channelId: user.live ? user.live.channelId : null, // channelId 추가
-        liveId: user.live ? user.live.id : null, // liveId 추가
+        channelId: user.live ? user.live.channelId : null,
+        liveId: user.live ? user.live.id : null,
       },
     };
   }
@@ -102,8 +102,8 @@ export class AuthService {
           id: user.id,
           nickname: user.nickname,
           profileImage: user.profileImage,
-          channelId: user.live.channelId, // channelId 추가
-          liveId: user.live.id, // liveId 추가
+          channelId: user.live ? user.live.channelId : null,
+          liveId: user.live ? user.live.id : null,
         },
       };
     } catch (error) {

--- a/Backend/src/categories/categories.controller.spec.ts
+++ b/Backend/src/categories/categories.controller.spec.ts
@@ -11,8 +11,8 @@ describe('CategoriesController', () => {
   let livesService: LivesService;
 
   const mockCategories = [
-    { id: 1, name: '게임', image: 'https://example.com/game.jpg' },
-    { id: 2, name: '음악', image: 'https://example.com/music.jpg' },
+    { id: 1, name: '게임', image: 'https://example.com/game.jpg', liveCount: 3, viewerCount: 50 },
+    { id: 2, name: '음악', image: 'https://example.com/music.jpg', liveCount: 5, viewerCount: 100 },
   ];
 
   const mockCategoriesService = {
@@ -66,7 +66,7 @@ describe('CategoriesController', () => {
     it('카테고리 컨트롤러가 단일 카테고리 정보를 반환합니다.', async () => {
       // Given
       const categoryId = 2;
-      const expectedCategory = { name: '음악', image: 'https://example.com/music.jpg' };
+      const expectedCategory = { name: '음악', image: 'https://example.com/music.jpg', liveCount: 5, viewerCount: 100 };
       mockCategoriesService.readCategory.mockResolvedValue(expectedCategory);
 
       // When
@@ -92,7 +92,7 @@ describe('CategoriesController', () => {
     });
   });
 
-  describe('getLivesByCategory', () => {
+  describe('getOnAirLivesByCategory', () => {
     it('카테고리 컨트롤러가 해당 카테고리의 방송중인 라이브 목록을 반환합니다.', async () => {
       // Given
       const categoriesId = 1;
@@ -111,7 +111,13 @@ describe('CategoriesController', () => {
 
       // Then
       expect(livesService.readLives).toHaveBeenCalledTimes(1);
-      expect(livesService.readLives).toHaveBeenCalledWith({ categoriesId, onAir: true });
+      expect(livesService.readLives).toHaveBeenCalledWith({
+        categoriesId,
+        onAir: true,
+        sort: 'latest',
+        limit: 20,
+        offset: 0,
+      });
       expect(lives).toEqual(mockLives);
     });
   });

--- a/Backend/src/follow/follow.controller.spec.ts
+++ b/Backend/src/follow/follow.controller.spec.ts
@@ -1,18 +1,97 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FollowController } from './follow.controller';
+import { FollowService } from './follow.service';
+import { UserEntity } from '../users/entity/user.entity';
 
 describe('FollowController', () => {
   let controller: FollowController;
+  let service: jest.Mocked<FollowService>;
+
+  const mockFollowService = {
+    getFollowingStreamers: jest.fn(),
+    followStreamer: jest.fn(),
+    unfollowStreamer: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FollowController],
+      providers: [{ provide: FollowService, useValue: mockFollowService }],
     }).compile();
 
     controller = module.get<FollowController>(FollowController);
+    service = module.get(FollowService) as jest.Mocked<FollowService>;
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // follow.controller.2. `getFollowing` 메서드 테스트 스위트 시작
+  describe('getFollowing', () => {
+    // follow.controller.2.1. 팔로우 목록 조회 테스트
+    it('should return the list of following streamers', async () => {
+      const userId = 1;
+      const req = {
+        user: { id: userId } as UserEntity,
+      } as any;
+
+      const followingStreamers = [
+        {
+          categoriesId: 1,
+          categoriesName: 'Category',
+          livesName: 'Live Stream',
+          channelId: 'channel123',
+          usersNickname: 'Streamer',
+          usersProfileImage: 'image.jpg',
+          onAir: true,
+        },
+      ];
+
+      service.getFollowingStreamers.mockResolvedValue(followingStreamers);
+
+      const result = await controller.getFollowing(req);
+
+      expect(service.getFollowingStreamers).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(followingStreamers);
+    });
+  });
+
+  // follow.controller.3. `followStreamer` 메서드 테스트 스위트 시작
+  describe('followStreamer', () => {
+    // follow.controller.3.1. 스트리머 팔로우 테스트
+    it('should follow a streamer successfully', async () => {
+      const userId = 1;
+      const streamerId = 2;
+      const req = {
+        user: { id: userId } as UserEntity,
+      } as any;
+
+      service.followStreamer.mockResolvedValue(undefined);
+
+      const result = await controller.followStreamer(req, streamerId);
+
+      expect(service.followStreamer).toHaveBeenCalledWith(userId, streamerId);
+      expect(result).toEqual({ message: '팔로우 성공' });
+    });
+  });
+
+  // follow.controller.4. `unfollowStreamer` 메서드 테스트 스위트 시작
+  describe('unfollowStreamer', () => {
+    // follow.controller.4.1. 스트리머 언팔로우 테스트
+    it('should unfollow a streamer successfully', async () => {
+      const userId = 1;
+      const streamerId = 2;
+      const req = {
+        user: { id: userId } as UserEntity,
+      } as any;
+
+      service.unfollowStreamer.mockResolvedValue(undefined);
+
+      const result = await controller.unfollowStreamer(req, streamerId);
+
+      expect(service.unfollowStreamer).toHaveBeenCalledWith(userId, streamerId);
+      expect(result).toEqual({ message: '언팔로우 성공' });
+    });
   });
 });

--- a/Backend/src/follow/follow.service.spec.ts
+++ b/Backend/src/follow/follow.service.spec.ts
@@ -1,18 +1,249 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FollowService } from './follow.service';
+import { UserEntity } from '../users/entity/user.entity';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('FollowService', () => {
   let service: FollowService;
+  let usersRepository: jest.Mocked<Repository<UserEntity>>;
+
+  const mockUsersRepository = {
+    findOne: jest.fn(),
+    findOneBy: jest.fn(),
+    save: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FollowService],
+      providers: [
+        FollowService,
+        { provide: getRepositoryToken(UserEntity), useValue: mockUsersRepository },
+      ],
     }).compile();
 
     service = module.get<FollowService>(FollowService);
+    usersRepository = module.get(getRepositoryToken(UserEntity)) as jest.Mocked<Repository<UserEntity>>;
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // follow.service.2. `followStreamer` 메서드 테스트 스위트 시작
+  describe('followStreamer', () => {
+    let userId: number;
+    let streamerId: number;
+    let user: UserEntity;
+    let streamer: UserEntity;
+
+    beforeEach(() => {
+      userId = 1;
+      streamerId = 2;
+
+      user = {
+        id: userId,
+        following: [],
+      } as UserEntity;
+
+      streamer = {
+        id: streamerId,
+      } as UserEntity;
+    });
+
+    // follow.service.2.1.1. 사용자가 스트리머를 성공적으로 팔로우하는 테스트
+    it('should follow a streamer successfully', async () => {
+      usersRepository.findOne.mockResolvedValue(user);
+      usersRepository.findOneBy.mockResolvedValue(streamer);
+      usersRepository.save.mockResolvedValue(undefined);
+
+      await service.followStreamer(userId, streamerId);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following'],
+      });
+
+      expect(usersRepository.findOneBy).toHaveBeenCalledWith({ id: streamerId });
+
+      expect(usersRepository.save).toHaveBeenCalledWith({
+        ...user,
+        following: [streamer],
+      });
+    });
+
+    // follow.service.2.1.2. 사용자가 자신을 팔로우하려 할 때 예외를 던지는 테스트
+    it('should throw BadRequestException when user tries to follow themselves', async () => {
+      await expect(service.followStreamer(userId, userId)).rejects.toThrow(BadRequestException);
+    });
+
+    // follow.service.2.1.3. 사용자가 존재하지 않을 때 예외를 던지는 테스트
+    it('should throw NotFoundException if user not found', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+      usersRepository.findOneBy.mockResolvedValue(streamer);
+
+      await expect(service.followStreamer(userId, streamerId)).rejects.toThrow(NotFoundException);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following'],
+      });
+    });
+
+    // follow.service.2.1.4. 스트리머가 존재하지 않을 때 예외를 던지는 테스트
+    it('should throw NotFoundException if streamer not found', async () => {
+      usersRepository.findOne.mockResolvedValue(user);
+      usersRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.followStreamer(userId, streamerId)).rejects.toThrow(NotFoundException);
+
+      expect(usersRepository.findOneBy).toHaveBeenCalledWith({ id: streamerId });
+    });
+
+    // follow.service.2.1.5. 이미 팔로우 중인 스트리머일 때 예외를 던지는 테스트
+    it('should throw BadRequestException if already following the streamer', async () => {
+      user.following = [streamer];
+
+      usersRepository.findOne.mockResolvedValue(user);
+      usersRepository.findOneBy.mockResolvedValue(streamer);
+
+      await expect(service.followStreamer(userId, streamerId)).rejects.toThrow(BadRequestException);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following'],
+      });
+    });
+  });
+
+  // follow.service.3. `unfollowStreamer` 메서드 테스트 스위트 시작
+  describe('unfollowStreamer', () => {
+    let userId: number;
+    let streamerId: number;
+    let user: UserEntity;
+    let streamer: UserEntity;
+
+    beforeEach(() => {
+      userId = 1;
+      streamerId = 2;
+
+      streamer = {
+        id: streamerId,
+      } as UserEntity;
+
+      user = {
+        id: userId,
+        following: [streamer],
+      } as UserEntity;
+    });
+
+    // follow.service.3.1.1. 사용자가 스트리머를 성공적으로 언팔로우하는 테스트
+    it('should unfollow a streamer successfully', async () => {
+      usersRepository.findOne.mockResolvedValue(user);
+      usersRepository.save.mockResolvedValue(undefined);
+
+      await service.unfollowStreamer(userId, streamerId);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following'],
+      });
+
+      expect(usersRepository.save).toHaveBeenCalledWith({
+        ...user,
+        following: [],
+      });
+    });
+
+    // follow.service.3.1.2. 사용자가 존재하지 않을 때 예외를 던지는 테스트
+    it('should throw NotFoundException if user not found', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.unfollowStreamer(userId, streamerId)).rejects.toThrow(NotFoundException);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following'],
+      });
+    });
+
+    // follow.service.3.1.3. 사용자가 해당 스트리머를 팔로우하고 있지 않을 때 예외를 던지는 테스트
+    it('should throw BadRequestException if not following the streamer', async () => {
+      user.following = []; // User is not following anyone
+
+      usersRepository.findOne.mockResolvedValue(user);
+
+      await expect(service.unfollowStreamer(userId, streamerId)).rejects.toThrow(BadRequestException);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following'],
+      });
+    });
+  });
+
+  // follow.service.4. `getFollowingStreamers` 메서드 테스트 스위트 시작
+  describe('getFollowingStreamers', () => {
+    let userId: number;
+    let streamer: UserEntity;
+    let user: UserEntity;
+
+    beforeEach(() => {
+      userId = 1;
+
+      streamer = {
+        id: 2,
+        nickname: 'Streamer',
+        profileImage: 'image.jpg',
+        live: {
+          category: { id: 1, name: 'Category' },
+          name: 'Live Stream',
+          channelId: 'channel123',
+          onAir: true,
+        },
+      } as UserEntity;
+
+      user = {
+        id: userId,
+        following: [streamer],
+      } as UserEntity;
+    });
+
+    // follow.service.4.1.1. 팔로우한 스트리머 목록을 성공적으로 반환하는 테스트
+    it('should return the list of following streamers', async () => {
+      usersRepository.findOne.mockResolvedValue(user);
+
+      const result = await service.getFollowingStreamers(userId);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following', 'following.live', 'following.live.category'],
+      });
+
+      expect(result).toEqual([
+        {
+          categoriesId: 1,
+          categoriesName: 'Category',
+          livesName: 'Live Stream',
+          channelId: 'channel123',
+          usersNickname: 'Streamer',
+          usersProfileImage: 'image.jpg',
+          onAir: true,
+        },
+      ]);
+    });
+
+    // follow.service.4.1.2. 사용자가 존재하지 않을 때 예외를 던지는 테스트
+    it('should throw NotFoundException if user not found', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getFollowingStreamers(userId)).rejects.toThrow(NotFoundException);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['following', 'following.live', 'following.live.category'],
+      });
+    });
   });
 });

--- a/Backend/src/users/users.controller.spec.ts
+++ b/Backend/src/users/users.controller.spec.ts
@@ -1,18 +1,206 @@
+// users.controller.spec.ts
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpdateUserDto } from './dto/update.user.dto';
+import { UserEntity } from './entity/user.entity';
+import { NotFoundException, ForbiddenException, BadRequestException } from '@nestjs/common';
 
 describe('UsersController', () => {
   let controller: UsersController;
+  let usersService: jest.Mocked<UsersService>;
 
+  // users.controller.1.1. Mock UsersService 정의
+  const mockUsersService = {
+    findById: jest.fn(),
+    updateUser: jest.fn(),
+  };
+
+  // users.controller.1.2. console.error를 모킹하여 테스트 중 에러 로그 숨기기
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  // users.controller.1.3. 모든 테스트 후 Mock 함수 복원
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  // users.controller.1.4. TestingModule 설정 및 의존성 주입
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: mockUsersService }],
     }).compile();
 
     controller = module.get<UsersController>(UsersController);
+    usersService = module.get(UsersService) as jest.Mocked<UsersService>;
   });
 
+  // users.controller.1.5. 각 테스트 후 Mock 함수 초기화
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // users.controller.2.1. 컨트롤러가 제대로 정의되었는지 확인하는 기본 테스트
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  // users.controller.3. getProfile 메서드 테스트 스위트 시작
+  describe('getProfile', () => {
+    const userId = 1;
+    const mockUser = {
+      id: userId,
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      createdAt: new Date(),
+    } as UserEntity;
+
+    // users.controller.3.1.1. 프로필을 성공적으로 가져오는 테스트
+    it('should return user profile', async () => {
+      usersService.findById.mockResolvedValue(mockUser);
+
+      const result = await controller.getProfile(userId);
+
+      expect(usersService.findById).toHaveBeenCalledWith(userId);
+
+      expect(result).toEqual({
+        users_id: mockUser.id,
+        nickname: mockUser.nickname,
+        profile_image: mockUser.profileImage,
+        created_at: mockUser.createdAt,
+      });
+    });
+
+    // users.controller.3.1.2. 사용자를 찾지 못한 경우 예외를 던지는 테스트
+    it('should throw NotFoundException if user not found', async () => {
+      usersService.findById.mockResolvedValue(null);
+
+      await expect(controller.getProfile(userId)).rejects.toThrow(NotFoundException);
+
+      expect(usersService.findById).toHaveBeenCalledWith(userId);
+    });
+  });
+
+  // users.controller.4. updateProfile 메서드 테스트 스위트 시작
+  describe('updateProfile', () => {
+    const userId = 1;
+    const mockUser = {
+      id: userId,
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      createdAt: new Date(),
+    } as UserEntity;
+    const updateUserDto: UpdateUserDto = {
+      nickname: 'UpdatedUser',
+      profileImage: 'https://example.com/updated-user.jpg',
+    };
+
+    // users.controller.4.1.1. 프로필을 성공적으로 업데이트하는 테스트
+    it('should update and return user profile', async () => {
+      const req = { user: { id: userId } } as any;
+
+      usersService.updateUser.mockResolvedValue({
+        ...mockUser,
+        ...updateUserDto,
+      } as UserEntity);
+
+      const result = await controller.updateProfile(
+        userId,
+        req,
+        updateUserDto,
+        undefined,
+      );
+
+      expect(usersService.updateUser).toHaveBeenCalledWith(
+        userId,
+        updateUserDto,
+        undefined,
+      );
+
+      expect(result).toEqual({
+        users_id: mockUser.id,
+        nickname: updateUserDto.nickname,
+        profile_image: updateUserDto.profileImage,
+        created_at: mockUser.createdAt,
+      });
+    });
+
+    // users.controller.4.1.2. 로그인한 사용자와 요청한 사용자 ID가 다른 경우 예외를 던지는 테스트
+    it('should throw ForbiddenException if user IDs do not match', async () => {
+      const req = { user: { id: 2 } } as any; // 다른 사용자 ID
+
+      await expect(
+        controller.updateProfile(userId, req, updateUserDto, undefined),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    // users.controller.4.1.3. 파일 업로드가 포함된 업데이트 테스트
+    it('should update profile with file upload', async () => {
+      const req = { user: { id: userId } } as any;
+
+      const mockFile = {
+        originalname: 'test.jpg',
+        buffer: Buffer.from('test'),
+        mimetype: 'image/jpeg',
+      } as Express.Multer.File;
+
+      usersService.updateUser.mockResolvedValue({
+        ...mockUser,
+        nickname: updateUserDto.nickname,
+        profileImage: 'https://ncloud-storage.com/profile-images/test.jpg',
+      } as UserEntity);
+
+      const result = await controller.updateProfile(
+        userId,
+        req,
+        updateUserDto,
+        mockFile,
+      );
+
+      expect(usersService.updateUser).toHaveBeenCalledWith(
+        userId,
+        updateUserDto,
+        mockFile,
+      );
+
+      expect(result).toEqual({
+        users_id: mockUser.id,
+        nickname: updateUserDto.nickname,
+        profile_image: 'https://ncloud-storage.com/profile-images/test.jpg',
+        created_at: mockUser.createdAt,
+      });
+    });
+
+    // users.controller.4.1.4. 사용자를 찾지 못한 경우 예외를 던지는 테스트
+    it('should throw NotFoundException if user not found', async () => {
+      const req = { user: { id: userId } } as any;
+
+      usersService.updateUser.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.updateProfile(userId, req, updateUserDto, undefined),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    // users.controller.4.1.5. 지원되지 않는 파일 형식일 경우 예외를 던지는 테스트
+    it('should throw BadRequestException if file type is unsupported', async () => {
+      const req = { user: { id: userId } } as any;
+
+      const mockFile = {
+        originalname: 'test.txt',
+        buffer: Buffer.from('test'),
+        mimetype: 'text/plain',
+      } as Express.Multer.File;
+
+      usersService.updateUser.mockRejectedValue(new BadRequestException());
+
+      await expect(
+        controller.updateProfile(userId, req, updateUserDto, mockFile),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/Backend/src/users/users.controller.spec.ts
+++ b/Backend/src/users/users.controller.spec.ts
@@ -1,5 +1,3 @@
-// users.controller.spec.ts
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';

--- a/Backend/src/users/users.service.spec.ts
+++ b/Backend/src/users/users.service.spec.ts
@@ -1,18 +1,381 @@
+// users.service.spec.ts
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
+import { Repository, DataSource, EntityManager } from 'typeorm';
+import { UserEntity } from './entity/user.entity';
+import { LiveEntity } from '../lives/entity/live.entity';
+import { getRepositoryToken, getDataSourceToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { CreateUserDto } from './dto/create.user.dto';
+import { UpdateUserDto } from './dto/update.user.dto';
+import {
+  NotFoundException,
+  InternalServerErrorException,
+  BadRequestException,
+} from '@nestjs/common';
+import { S3 } from '@aws-sdk/client-s3';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let usersRepository: jest.Mocked<Repository<UserEntity>>;
+  let livesRepository: jest.Mocked<Repository<LiveEntity>>;
+  let dataSource: DataSource;
+  let configService: jest.Mocked<ConfigService>;
 
+  // users.service.1.1. Mock Repository 정의
+  const mockUsersRepository = {
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockLivesRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  // users.service.1.2. Mock DataSource 정의
+  const mockDataSource = {
+    transaction: jest.fn(),
+  };
+
+  // users.service.1.3. Mock ConfigService 정의
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  // users.service.1.4. console.error를 모킹하여 테스트 중 에러 로그 숨기기
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  // users.service.1.5. 모든 테스트 후 Mock 함수 복원
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  // users.service.1.6. TestingModule 설정 및 의존성 주입
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        { provide: getRepositoryToken(UserEntity), useValue: mockUsersRepository },
+        { provide: getRepositoryToken(LiveEntity), useValue: mockLivesRepository },
+        { provide: getDataSourceToken(), useValue: mockDataSource },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
+    usersRepository = module.get(getRepositoryToken(UserEntity)) as jest.Mocked<Repository<UserEntity>>;
+    livesRepository = module.get(getRepositoryToken(LiveEntity)) as jest.Mocked<Repository<LiveEntity>>;
+    dataSource = module.get(getDataSourceToken());
+    configService = module.get(ConfigService) as jest.Mocked<ConfigService>;
+
+    // S3 인스턴스 모킹
+    service['s3'] = {
+      send: jest.fn(),
+    } as unknown as jest.Mocked<S3>;
   });
 
+  // users.service.1.7. 각 테스트 후 Mock 함수 초기화
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // users.service.2.1. 서비스가 제대로 정의되었는지 확인하는 기본 테스트
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  // users.service.3. findByOAuthUid 메서드 테스트 스위트 시작
+  describe('findByOAuthUid', () => {
+    const oauthUid = 'test-oauth-uid';
+    const oauthPlatform: 'google' | 'github' | 'naver' = 'github';
+    const mockUser = {
+      id: 1,
+      oauthUid,
+      oauthPlatform,
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      live: null,
+      following: [],
+    } as UserEntity;
+
+    // users.service.3.1.1. 사용자를 성공적으로 찾는 테스트
+    it('should return user if found', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      const result = await service.findByOAuthUid(oauthUid, oauthPlatform);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { oauthUid, oauthPlatform },
+        relations: ['live'],
+      });
+      expect(result).toEqual(mockUser);
+    });
+
+    // users.service.3.1.2. 사용자를 찾지 못한 경우 null을 반환하는 테스트
+    it('should return null if user not found', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.findByOAuthUid(oauthUid, oauthPlatform);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { oauthUid, oauthPlatform },
+        relations: ['live'],
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  // users.service.4. findById 메서드 테스트 스위트 시작
+  describe('findById', () => {
+    const userId = 1;
+    const mockUser = {
+      id: userId,
+      oauthUid: 'test-oauth-uid',
+      oauthPlatform: 'github' as 'naver' | 'github' | 'google',
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      live: null,
+      following: [],
+    } as UserEntity;
+
+    // users.service.4.1.1. 사용자를 성공적으로 찾는 테스트
+    it('should return user if found', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      const result = await service.findById(userId);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['live'],
+      });
+      expect(result).toEqual(mockUser);
+    });
+
+    // users.service.4.1.2. 사용자를 찾지 못한 경우 null을 반환하는 테스트
+    it('should return null if user not found', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.findById(userId);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        relations: ['live'],
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  // users.service.5. createUser 메서드 테스트 스위트 시작
+  describe('createUser', () => {
+    const createUserDto: CreateUserDto = {
+      oauthUid: 'test-oauth-uid',
+      oauthPlatform: 'github',
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+    };
+
+    const mockUser = {
+      id: 1,
+      ...createUserDto,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      live: { id: 1 },
+      following: [],
+    } as UserEntity;
+
+    // users.service.5.1.1. 사용자를 성공적으로 생성하는 테스트
+    it('should create and return the new user', async () => {
+      const mockTransactionManager = {
+        create: jest.fn(),
+        save: jest.fn(),
+      };
+
+      // dataSource.transaction 메서드를 any로 캐스팅하여 타입 오류 해결
+      (dataSource.transaction as any).mockImplementation(
+        async (cb: (manager: EntityManager) => Promise<any>) => {
+          return await cb(mockTransactionManager as unknown as EntityManager);
+        },
+      );
+
+      mockTransactionManager.create
+        .mockReturnValueOnce({ id: 1 } as LiveEntity) // For LiveEntity
+        .mockReturnValueOnce(mockUser); // For UserEntity
+
+      mockTransactionManager.save
+        .mockResolvedValueOnce({ id: 1 } as LiveEntity) // Saved LiveEntity
+        .mockResolvedValueOnce(mockUser); // Saved UserEntity
+
+      const result = await service.createUser(createUserDto);
+
+      expect(dataSource.transaction).toHaveBeenCalled();
+
+      expect(mockTransactionManager.create).toHaveBeenNthCalledWith(
+        1,
+        LiveEntity,
+        expect.objectContaining({
+          categoriesId: null,
+          channelId: expect.any(String),
+          name: null,
+          description: null,
+          streamingKey: expect.any(String),
+          onAir: false,
+          startedAt: null,
+        }),
+      );
+
+      expect(mockTransactionManager.create).toHaveBeenNthCalledWith(
+        2,
+        UserEntity,
+        {
+          ...createUserDto,
+          live: { id: 1 },
+        },
+      );
+
+      expect(result).toEqual(mockUser);
+    });
+
+    // users.service.5.1.2. 트랜잭션 에러가 발생한 경우 예외를 던지는 테스트
+    it('should throw an error if transaction fails', async () => {
+      (dataSource.transaction as any).mockRejectedValue(new Error('Transaction Error'));
+
+      await expect(service.createUser(createUserDto)).rejects.toThrow('Transaction Error');
+
+      expect(dataSource.transaction).toHaveBeenCalled();
+    });
+  });
+
+  // users.service.6. updateUser 메서드 테스트 스위트 시작
+  describe('updateUser', () => {
+    const userId = 1;
+    const updateUserDto: UpdateUserDto = {
+      nickname: 'UpdatedUser',
+      profileImage: 'https://example.com/updated-user.jpg',
+    };
+
+    const mockUser = {
+      id: userId,
+      oauthUid: 'test-oauth-uid',
+      oauthPlatform: 'github' as 'naver' | 'github' | 'google',
+      nickname: 'TestUser',
+      profileImage: 'https://example.com/test-user.jpg',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+      live: null,
+      following: [],
+    } as UserEntity;
+
+    // users.service.6.1.1. 사용자를 성공적으로 업데이트하는 테스트
+    it('should update and return the user', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+      usersRepository.save.mockResolvedValue({
+        ...mockUser,
+        ...updateUserDto,
+        updatedAt: new Date(),
+      } as UserEntity);
+
+      const result = await service.updateUser(userId, updateUserDto);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+
+      expect(usersRepository.save).toHaveBeenCalledWith({
+        ...mockUser,
+        ...updateUserDto,
+        updatedAt: expect.any(Date),
+      });
+
+      expect(result).toEqual({
+        ...mockUser,
+        ...updateUserDto,
+        updatedAt: expect.any(Date),
+      });
+    });
+
+    // users.service.6.1.2. 파일 업로드가 포함된 업데이트 테스트
+    it('should upload file and update user when file is provided', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      const mockFile = {
+        originalname: 'test.jpg',
+        buffer: Buffer.from('test'),
+        mimetype: 'image/jpeg',
+      } as Express.Multer.File;
+
+      const uploadedUrl = 'https://ncloud-storage.com/profile-images/test.jpg';
+
+      // uploadFileToNcloud 메서드를 모킹
+      jest.spyOn<any, any>(service, 'uploadFileToNcloud').mockResolvedValue(uploadedUrl);
+
+      usersRepository.save.mockResolvedValue({
+        ...mockUser,
+        nickname: updateUserDto.nickname,
+        profileImage: uploadedUrl,
+        updatedAt: new Date(),
+      } as UserEntity);
+
+      const result = await service.updateUser(userId, updateUserDto, mockFile);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+
+      expect(service['uploadFileToNcloud']).toHaveBeenCalledWith(mockFile);
+
+      expect(usersRepository.save).toHaveBeenCalledWith({
+        ...mockUser,
+        nickname: updateUserDto.nickname,
+        profileImage: uploadedUrl,
+        updatedAt: expect.any(Date),
+      });
+
+      expect(result).toEqual({
+        ...mockUser,
+        nickname: updateUserDto.nickname,
+        profileImage: uploadedUrl,
+        updatedAt: expect.any(Date),
+      });
+    });
+
+    // users.service.6.1.3. 사용자를 찾지 못한 경우 예외를 던지는 테스트
+    it('should throw NotFoundException if user not found', async () => {
+      usersRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.updateUser(userId, updateUserDto)).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+    });
+
+    // users.service.6.1.4. 지원되지 않는 파일 형식일 경우 예외를 던지는 테스트
+    it('should throw BadRequestException if file type is unsupported', async () => {
+      usersRepository.findOne.mockResolvedValue(mockUser);
+
+      const mockFile = {
+        originalname: 'test.txt',
+        buffer: Buffer.from('test'),
+        mimetype: 'text/plain',
+      } as Express.Multer.File;
+
+      jest.spyOn<any, any>(service, 'uploadFileToNcloud').mockImplementation(() => {
+        throw new BadRequestException('지원되지 않는 이미지 형식입니다.');
+      });
+
+      await expect(
+        service.updateUser(userId, updateUserDto, mockFile),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(usersRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+    });
   });
 });

--- a/Backend/src/users/users.service.spec.ts
+++ b/Backend/src/users/users.service.spec.ts
@@ -1,5 +1,3 @@
-// users.service.spec.ts
-
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { Repository, DataSource, EntityManager } from 'typeorm';


### PR DESCRIPTION
## 📝 PR 설명
users, follow 모듈의 테스트 코드를 새로 작성했습니다. auth 는 기존 코드를 리팩토링했습니다. categories 테스트 코드에 viewerCount, liveCount 업데이트 했습니다.

### npm test 결과
```
Test Suites: 4 failed, 11 passed, 15 total
Tests:       1 failed, 58 passed, 59 total
Snapshots:   0 total
Time:        39.4 s, estimated 51 s
Ran all test suites.
```
- `lives`, `chats` 모듈의 테스트 코드만 작성하면 테스트 커버리지가 100% 로 될 거 같습니다.

## ✅ 주요 변경 사항

- Refactor
  - [ ] auth.service.spec.ts
  - [ ] auth.controller.spec.ts
- Create
  - [ ] users.service.spec.ts
  - [ ] users.controller.spec.ts
  - [ ] follow.service.spec.ts
  - [ ] follow.controller.spec.ts
- Update
  - [ ] categories.service.spec.ts
  - [ ] categories.controller.spec.ts
## 📸 스크린샷 (선택)


## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)

