### PR TITLE
[Feature] 스트리머 팔로우 수 조회 API

### DIFF
--- a/Backend/apps/api/src/follow/follow.controller.ts
+++ b/Backend/apps/api/src/follow/follow.controller.ts
@@ -15,12 +15,12 @@ import { Request } from 'express';
 import { UserEntity } from '../users/entity/user.entity';
 
 @Controller('follow')
-@UseGuards(JwtAuthGuard)
 export class FollowController {
   constructor(private readonly followService: FollowService) {}
 
   // 팔로우한 스트리머 목록 조회
   @Get()
+  @UseGuards(JwtAuthGuard)
   async getFollowing(@Req() req: Request & { user: UserEntity }) {
     const userId = req.user.id;
     return this.followService.getFollowingStreamers(userId);
@@ -28,6 +28,7 @@ export class FollowController {
 
   // 스트리머 팔로우
   @Post(':streamerId')
+  @UseGuards(JwtAuthGuard)
   @HttpCode(201)
   async followStreamer(
     @Req() req: Request & { user: UserEntity },
@@ -40,6 +41,7 @@ export class FollowController {
 
   // 스트리머 언팔로우
   @Delete(':streamerId')
+  @UseGuards(JwtAuthGuard)
   async unfollowStreamer(
     @Req() req: Request & { user: UserEntity },
     @Param('streamerId', ParseIntPipe) streamerId: number,
@@ -47,5 +49,13 @@ export class FollowController {
     const userId = req.user.id;
     await this.followService.unfollowStreamer(userId, streamerId);
     return { message: '언팔로우 성공' };
+  }
+
+  @Get('count/:streamerId')
+  async getFollowerCount(
+    @Param('streamerId', ParseIntPipe) streamerId: number,
+  ) {
+    const followerCount = await this.followService.getFollowerCount(streamerId);
+    return { streamerId, followerCount };
   }
 }

--- a/Backend/apps/api/src/follow/follow.service.ts
+++ b/Backend/apps/api/src/follow/follow.service.ts
@@ -85,4 +85,15 @@ export class FollowService {
       onAir: streamer.live?.onAir || false,
     }));
   }
+
+  // 팔로워 수
+  async getFollowerCount(streamerId: number): Promise<number> {
+    const count = await this.usersRepository
+      .createQueryBuilder('user')
+      .innerJoin('user.followers', 'follower')
+      .where('user.id = :streamerId', { streamerId })
+      .getCount();
+  
+    return count;
+  }
 }

--- a/Backend/apps/api/src/users/entity/user.entity.ts
+++ b/Backend/apps/api/src/users/entity/user.entity.ts
@@ -47,18 +47,20 @@ export class UserEntity {
   @JoinColumn({ name: 'lives_id' })
   live: LiveEntity;
 
-    // 👇 following 프로퍼티 추가
-    @ManyToMany(() => UserEntity)
-    @JoinTable({
-      name: 'follows',
-      joinColumn: {
-        name: 'follower_id',
-        referencedColumnName: 'id',
-      },
-      inverseJoinColumn: {
-        name: 'streamer_id',
-        referencedColumnName: 'id',
-      },
-    })
-    following: UserEntity[];
+  @ManyToMany(() => UserEntity, (user) => user.followers)
+  @JoinTable({
+    name: 'follows',
+    joinColumn: {
+      name: 'follower_id',
+      referencedColumnName: 'id',
+    },
+    inverseJoinColumn: {
+      name: 'streamer_id',
+      referencedColumnName: 'id',
+    },
+  })
+  following: UserEntity[];
+
+  @ManyToMany(() => UserEntity, (user) => user.following)
+  followers: UserEntity[];
 }


### PR DESCRIPTION
## 📝 PR 설명

### **스트리머 팔로우 수 조회 API 작성**

- **엔드포인트:** `GET /follow/count/streamerId`
- **설명:** 스트리머의 수 확인
- **인증:** 필요
- **파라미터:**
    - **경로:**
        - `streamerId` (정수, 필수): 스트리머의 ID.
- **응답:**
    - **성공 (200):** 확인 메시지.
    - **오류 (400/500):**

### 성공 시
```
{
    "streamerId": 1,
    "followerCount": 1
}

```

## ✅ 주요 변경 사항
- [ ] 유저 엔티티에 팔로우 역관계 생성

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1f004ff2-da6b-4f6a-9bf0-530a81541068)


## 🔗 관련 이슈


## 🛠️ 추가 작업 (선택)
