### PR TITLE
[Config] 방송 송출 종료 5초 후 방종 처리되도록 스크립트 변경

### DIFF
--- a/Backend/apps/api/src/lives/lives.controller.ts
+++ b/Backend/apps/api/src/lives/lives.controller.ts
@@ -68,10 +68,10 @@ export class LivesController {
     return { code: 0 };
   }
 
-  @Delete('/onair/:channelId')
+  @Delete('/onair/:streamingKey')
   @HttpCode(202)
-  async endLive(@Param('channelId') channelId: UUID) {
-    this.livesService.endLive(channelId);
+  async endLive(@Param('streamingKey') streamingKey: UUID) {
+    this.livesService.endLive(streamingKey);
   }
 
   @Get('/status/:channelId')

--- a/Backend/apps/api/src/lives/lives.service.ts
+++ b/Backend/apps/api/src/lives/lives.service.ts
@@ -1,7 +1,7 @@
 import { ConflictException, Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { LiveEntity } from './entity/live.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsWhere, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { LivesDto } from './dto/lives.dto';
 import { LiveDto } from './dto/live.dto';
 import { UUID } from 'crypto';
@@ -134,8 +134,8 @@ export class LivesService {
     await this.livesRepository.update({ streamingKey }, { startedAt: new Date(), onAir: true, viewers: 0 });
   }
 
-  async endLive(channelId: UUID) {
-    this.livesRepository.update({ channelId }, { onAir: false });
+  async endLive(streamingKey: UUID) {
+    this.livesRepository.update({ streamingKey }, { onAir: false });
   }
 
   async readStatus(channelId: UUID) {

--- a/Backend/server/encoding/cleanup.sh
+++ b/Backend/server/encoding/cleanup.sh
@@ -22,9 +22,9 @@ fi
 
 
 if [[ "$APP_NAME" == "live" ]]; then
-    curl -X DELETE http://192.168.1.9:3000/lives/onair/$CHANNEL_ID
+    curl -X DELETE http://192.168.1.9:3000/lives/onair/$STREAM_KEY
 elif [[ "$APP_NAME" == "dev" ]]; then
-    curl -X DELETE http://192.168.1.7:3000/lives/onair/$CHANNEL_ID
+    curl -X DELETE http://192.168.1.7:3000/lives/onair/$STREAM_KEY
 else
     echo "Error: Unsupported APP_NAME. Exiting."
     exit 1

--- a/Backend/server/encoding/cleanup.sh
+++ b/Backend/server/encoding/cleanup.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 
-#LOG_FILE="/lico/script/cleanup.log"
-#exec > >(tee -a "$LOG_FILE") 2>&1
+LOG_FILE="/lico/script/cleanup.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 
 APP_NAME=$1
-CHANNEL_ID=$2
+STREAM_KEY=$2
 
-echo "Cleanup FFmpeg script for APP_NAME: $APP_NAME, CHANNEL_ID: $CHANNEL_ID"
+sleep 5; # 송출 종료 5초 후 방종 처리
+
+echo "Cleanup FFmpeg script for APP_NAME: $APP_NAME, STREAM_KEY: $STREAM_KEY"
+# API 요청으로 채널 아이디 획득
+if [[ "$APP_NAME" == "live" ]]; then
+    CHANNEL_ID=$(curl -s http://192.168.1.9:3000/lives/channel-id/$STREAM_KEY | jq -r '.channelId')
+elif [[ "$APP_NAME" == "dev" ]]; then
+    CHANNEL_ID=$(curl -s http://192.168.1.7:3000/lives/channel-id/$STREAM_KEY | jq -r '.channelId')
+else
+    echo "Error: Unsupported APP_NAME. Exiting."
+    exit 1
+fi
+
 
 if [[ "$APP_NAME" == "live" ]]; then
     curl -X DELETE http://192.168.1.9:3000/lives/onair/$CHANNEL_ID
@@ -23,3 +35,4 @@ if [[ -d "/lico/storage/$APP_NAME/$CHANNEL_ID" ]]; then
     echo "Deleted directory: /lico/storage/$APP_NAME/$CHANNEL_ID"
 else
     echo "Directory /lico/storage/$APP_NAME/$CHANNEL_ID does not exist, skipping deletion."
+fi

--- a/Backend/server/encoding/nginx.conf
+++ b/Backend/server/encoding/nginx.conf
@@ -16,13 +16,16 @@ rtmp {
                 application live {
                         exec_publish /lico/script/stream_process.sh $app $name;
 
+                        exec_publish_done /lico/script/cleanup.sh $app $name
+
                         access_log /var/log/nginx/rtmp_access.log;
                         }
                 application dev {
                         exec_publish /lico/script/stream_process.sh $app $name;
 
+                        exec_publish_done /lico/script/cleanup.sh $app $name;
+
                         access_log /var/log/nginx/rtmp_access.log;
                         }
         }
-
 }

--- a/Backend/server/encoding/stream_process.sh
+++ b/Backend/server/encoding/stream_process.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#LOG_FILE="/lico/script/logfile.log"
-#exec > >(tee -a "$LOG_FILE") 2>&1
+LOG_FILE="/lico/script/logfile.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 APP_NAME=$1
 STREAM_KEY=$2
@@ -17,25 +17,21 @@ else
     exit 1
 fi
 
-
 if [[ -z "$CHANNEL_ID" ]]; then
     echo "Error: CHANNEL_ID is empty. Exiting."
     exit 1
 fi
 
+
 ffmpeg -rw_timeout 10000000 -r 30 -i "rtmp://192.168.1.6:1935/$APP_NAME/$STREAM_KEY" \
         -filter_complex "[0:v]split=3[720p][for480p][for360p];[for480p]scale=854:480[480p];[for360p]scale=640:360[360p]" \
-        -map "[720p]" -map 0:a -c:v:0 libx264 -b:v:0 2800k -s:v:0 1280x720 -preset ultrafast -g 30 -tune zerolatency -profile:v:0 baseline -c:a:0 aac -b:a:0 128k \
-        -map "[480p]" -map 0:a -c:v:1 libx264 -b:v:1 1200k -preset ultrafast -g 30 -tune zerolatency -profile:v:1 baseline -c:a:1 copy \
-        -map "[360p]" -map 0:a -c:v:2 libx264 -b:v:2 600k -preset ultrafast -g 30 -tune zerolatency -profile:v:2 baseline -c:a:2 copy \
+        -map "[720p]" -map 0:a? -c:v:0 libx264 -b:v:0 2800k -s:v:0 1280x720 -preset ultrafast -g 30 -tune zerolatency -profile:v:0 baseline -c:a aac -b:a 128k \
+        -map "[480p]" -map 0:a? -c:v:1 libx264 -b:v:1 1200k -preset ultrafast -g 30 -tune zerolatency -profile:v:1 baseline -c:a aac -b:a 128k \
+        -map "[360p]" -map 0:a? -c:v:2 libx264 -b:v:2 600k -preset ultrafast -g 30 -tune zerolatency -profile:v:2 baseline -c:a aac -b:a 128k \
         -keyint_min 30 -hls_time 1 -hls_segment_type fmp4 -hls_flags delete_segments+independent_segments+append_list \
         -hls_list_size 3 -hls_delete_threshold 5 \
         -hls_segment_filename "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/%03d.m4s" \
         -master_pl_name "index.m3u8" \
-        -var_stream_map "v:0,a:0 v:1,a:1 v:2,a:2" \
+        -var_stream_map "v:2,a:2 v:1,a:1 v:0,a:0" \
         -f hls "/lico/storage/$APP_NAME/$CHANNEL_ID/%v/index.m3u8" \
         -map 0:v -vf "fps=1/10,scale=426:240" -update 1 "/lico/storage/$APP_NAME/$CHANNEL_ID/thumbnail.jpg"
-
-
-
-/lico/script/cleanup.sh "$APP_NAME" "$CHANNEL_ID"

--- a/Backend/server/encoding/stream_process.sh
+++ b/Backend/server/encoding/stream_process.sh
@@ -23,7 +23,7 @@ if [[ -z "$CHANNEL_ID" ]]; then
 fi
 
 
-ffmpeg -rw_timeout 10000000 -r 30 -i "rtmp://192.168.1.6:1935/$APP_NAME/$STREAM_KEY" \
+ffmpeg -rw_timeout 10000000 -r 30 -i "rtmp://192.168.1.6:1935/$APP_NAME/$STREAM_KEY" -y \
         -filter_complex "[0:v]split=3[720p][for480p][for360p];[for480p]scale=854:480[480p];[for360p]scale=640:360[360p]" \
         -map "[720p]" -map 0:a? -c:v:0 libx264 -b:v:0 2800k -s:v:0 1280x720 -preset ultrafast -g 30 -tune zerolatency -profile:v:0 baseline -c:a aac -b:a 128k \
         -map "[480p]" -map 0:a? -c:v:1 libx264 -b:v:1 1200k -preset ultrafast -g 30 -tune zerolatency -profile:v:1 baseline -c:a aac -b:a 128k \


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
기존에는 연결이 끊어지면 ffmpeg이 종료가 끊어지는 것을 이용해 cleanup 스크립트를 호출하였으나 publish_done 이벤트에서 cleanup 스크립트를 5초 후에 실행 시키는 것으로 변경하였습니다.

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->
- stream_process 스크립트에서 cleanup 스크립트 호출하지 않게 수정
- publish_done 이벤트에서 cleanup 스크립트 호출하도록 변경
- DELETE /onair/:streamingKey api 경로 변수 잘못 들어가 있던 것 수정

- closes #272 