### PR TITLE
[Fix] oldchats가 2중배열로 전달되는 문제 수정

### DIFF
--- a/Backend/apps/chats/src/chats.gateway.ts
+++ b/Backend/apps/chats/src/chats.gateway.ts
@@ -57,7 +57,7 @@ export class ChatsGateway implements OnGatewayDisconnect, OnGatewayConnection {
       .lrange(`${channelId}:chats`, -this.OLD_CHATS_MAXIMUM_SIZE, -1)
       .exec();
 
-    socket.emit('chat', results[1]);
+    socket.emit('chat', results[1][1]);
   }
 
   async handleDisconnect(socket: Socket) {


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
redis mulit 사용하면서 결과를 이중배열로 받게 되었으나 해당 부분 고려하지 않아 응답이 2중배열로 반환되었음

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

- oldchats를 기존과 동일하게 배열로 반환하도록 수정

## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->
