### PR TITLE
[Feature] 채팅 클린봇 모드 구현

### DIFF
--- a/Frontend/src/components/chat/ChatHeader.tsx
+++ b/Frontend/src/components/chat/ChatHeader.tsx
@@ -22,16 +22,16 @@ export default function ChatHeader({ onClose, onSettingsClick }: ChatHeaderProps
         aria-label="채팅창 닫기"
         type="button"
         onClick={onClose}
-        className="text-lico-gray-2 hover:text-lico-gray-1"
+        className="rounded-md p-2 text-lico-gray-2 hover:bg-lico-gray-3"
       >
         {videoPlayerState && isVerticalMode ? <LuArrowDownToLine size={20} /> : <LuArrowRightToLine size={20} />}
       </button>
-      <h3 className="font-bold text-base text-lico-orange-2">채팅</h3>
+      <h3 className="font-bold text-xl text-lico-orange-2">채팅</h3>
       <button
         aria-label="채팅창 설정"
         type="button"
         onClick={onSettingsClick}
-        className="rounded-md p-2 text-lico-gray-2 hover:text-lico-gray-1"
+        className="rounded-md p-2 text-lico-gray-2 hover:bg-lico-gray-3"
       >
         <HiDotsVertical size={20} />
       </button>

--- a/Frontend/src/components/chat/ChatMessage.tsx
+++ b/Frontend/src/components/chat/ChatMessage.tsx
@@ -1,30 +1,36 @@
 interface ChatMessageProps {
-  id: number;
+  userId: number;
   content: string;
   nickname: string;
   timestamp?: string;
   color?: string;
   onUserClick: (userId: number, element: HTMLElement) => void;
+  filteringResult: boolean;
 }
 
 export default function ChatMessage({
-  id,
+  userId,
   content,
   nickname,
   timestamp = '',
   color = 'text-lico-orange-2',
   onUserClick,
+  filteringResult,
 }: ChatMessageProps) {
   return (
     <button
       type="button"
       className="z-20 rounded-3xl p-1.5 hover:bg-lico-gray-3"
-      onClick={e => onUserClick(id, e.currentTarget)}
+      onClick={e => onUserClick(userId, e.currentTarget)}
     >
       <div className="flex gap-1.5 px-1">
         {timestamp && <span className="font-medium text-xs text-lico-gray-2">{timestamp}</span>}
         <span className={`max-w-40 truncate whitespace-nowrap font-bold text-base ${color}`}>{nickname}</span>
-        <p className="flex items-center break-all text-start font-medium text-sm text-lico-gray-1">{content}</p>
+        <p
+          className={`flex items-center break-all text-start font-medium text-sm ${filteringResult ? 'text-lico-gray-1' : 'text-lico-gray-2'}`}
+        >
+          {content}
+        </p>
       </div>
     </button>
   );

--- a/Frontend/src/components/chat/ChatSettingsMenu.tsx
+++ b/Frontend/src/components/chat/ChatSettingsMenu.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { RiRobot2Line } from 'react-icons/ri';
+import { BsBoxArrowUpRight } from 'react-icons/bs';
+import Toggle from '@components/common/Toggle';
+
+interface ChatSettingsMenuProps {
+  onClose?: () => void;
+  position?: {
+    top: string;
+    right: string;
+  };
+}
+
+function ChatSettingsMenu({ onClose, position = { top: '50px', right: '8px' } }: ChatSettingsMenuProps) {
+  const [cleanBot, setCleanBot] = useState(false);
+
+  return (
+    <>
+      <button aria-label="채팅세팅메뉴 닫기" type="button" className="z fixed inset-0" onClick={onClose} />
+      <div
+        className="absolute z-50 min-w-[252px] rounded-lg border border-lico-gray-3 bg-lico-gray-5 p-1 shadow-lg"
+        style={{
+          top: position.top,
+          right: position.right,
+        }}
+      >
+        <div className="flex w-full items-center justify-between rounded-md px-3 py-2 hover:bg-lico-gray-4">
+          <div className="flex items-center gap-3 font-bold text-lg text-lico-gray-2">
+            <RiRobot2Line size={18} />
+            <span>클린봇</span>
+          </div>
+          <Toggle checked={cleanBot} onChange={setCleanBot} />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => window.open('/chat-popup', '_blank', 'width=400,height=600')}
+          className="flex w-full items-center justify-between rounded-md px-3 py-2 hover:bg-lico-gray-4"
+        >
+          <div className="flex items-center gap-3 font-bold text-lg text-lico-gray-2">
+            <BsBoxArrowUpRight size={16} />
+            <span>채팅창 팝업</span>
+          </div>
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default ChatSettingsMenu;

--- a/Frontend/src/components/chat/ChatSettingsMenu.tsx
+++ b/Frontend/src/components/chat/ChatSettingsMenu.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { RiRobot2Line } from 'react-icons/ri';
 import { BsBoxArrowUpRight } from 'react-icons/bs';
 import Toggle from '@components/common/Toggle';
@@ -9,11 +8,16 @@ interface ChatSettingsMenuProps {
     top: string;
     right: string;
   };
+  cleanBotEnabled: boolean;
+  onCleanBotChange: (enabled: boolean) => void;
 }
 
-function ChatSettingsMenu({ onClose, position = { top: '50px', right: '8px' } }: ChatSettingsMenuProps) {
-  const [cleanBot, setCleanBot] = useState(false);
-
+function ChatSettingsMenu({
+  onClose,
+  position = { top: '50px', right: '8px' },
+  cleanBotEnabled,
+  onCleanBotChange,
+}: ChatSettingsMenuProps) {
   return (
     <>
       <button aria-label="채팅세팅메뉴 닫기" type="button" className="z fixed inset-0" onClick={onClose} />
@@ -29,7 +33,7 @@ function ChatSettingsMenu({ onClose, position = { top: '50px', right: '8px' } }:
             <RiRobot2Line size={18} />
             <span>클린봇</span>
           </div>
-          <Toggle checked={cleanBot} onChange={setCleanBot} />
+          <Toggle checked={cleanBotEnabled} onChange={onCleanBotChange} />
         </div>
 
         <button

--- a/Frontend/src/components/chat/ChatWindow.tsx
+++ b/Frontend/src/components/chat/ChatWindow.tsx
@@ -10,6 +10,7 @@ import { config } from '@config/env';
 import ChatProfileModal from '@components/chat/ChatProfileModal';
 import PendingMessageNotification from '@components/chat/PendingMessageNotification';
 import { chatApi } from '@apis/chat.ts';
+import ChatSettingsMenu from '@components/chat/ChatSettingsMenu';
 import type { Message } from '@/types/live';
 import ChatMessage from './ChatMessage';
 
@@ -35,6 +36,7 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [selectedMessage, setSelectedMessage] = useState<SelectedMessage | null>(null);
   const [isScrollPaused, setIsScrollPaused] = useState(false);
+  const [showChatSettingsMenu, setShowChatSettingsMenu] = useState(false);
   const [showPendingMessages, setShowPendingMessages] = useState(false);
   const [pendingMessages, setPendingMessages] = useState<Message[]>([]);
   const chatRef = useRef<HTMLDivElement | null>(null);
@@ -131,9 +133,6 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
 
     const socket = io(`${config.chatUrl}`, {
       transports: ['websocket'],
-      extraHeaders: {
-        Authorization: `Bearer ${accessToken}`, // 헤더에 토큰 추가
-      },
     });
 
     socket.emit('join', { channelId: id });
@@ -162,7 +161,8 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
 
   return (
     <div className="relative flex h-full flex-col border-l border-lico-gray-3 bg-lico-gray-4">
-      <ChatHeader onClose={toggleChat} onSettingsClick={() => {}} />
+      <ChatHeader onClose={toggleChat} onSettingsClick={() => setShowChatSettingsMenu(!showChatSettingsMenu)} />
+      {showChatSettingsMenu && <ChatSettingsMenu onClose={() => setShowChatSettingsMenu(false)} />}
       <div
         role="log"
         aria-label="채팅 메시지"

--- a/Frontend/src/components/chat/ChatWindow.tsx
+++ b/Frontend/src/components/chat/ChatWindow.tsx
@@ -1,18 +1,18 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { FaAngleDown } from 'react-icons/fa';
-import ChatHeader from '@components/chat/ChatHeader';
-import ChatInput from '@components/chat/ChatInput';
-import useLayoutStore from '@store/useLayoutStore';
-import { getConsistentTextColor } from '@utils/chatUtils';
 import { io, Socket } from 'socket.io-client';
+import { FaAngleDown } from 'react-icons/fa';
+import { getConsistentTextColor } from '@utils/chatUtils';
+import { chatApi } from '@apis/chat';
 import { useAuthStore } from '@store/useAuthStore';
 import { config } from '@config/env';
+import useLayoutStore from '@store/useLayoutStore';
+import ChatHeader from '@components/chat/ChatHeader';
+import ChatInput from '@components/chat/ChatInput';
 import ChatProfileModal from '@components/chat/ChatProfileModal';
 import PendingMessageNotification from '@components/chat/PendingMessageNotification';
-import { chatApi } from '@apis/chat.ts';
 import ChatSettingsMenu from '@components/chat/ChatSettingsMenu';
-import type { Message } from '@/types/live';
 import ChatMessage from './ChatMessage';
+import type { Message } from '@/types/live';
 
 interface ChatWindowProps {
   onAir: boolean;
@@ -25,6 +25,7 @@ interface SelectedMessage {
 }
 
 const MESSAGE_LIMIT = 200;
+const CLEAN_BOT_MESSAGE = '클린봇이 삭제한 메세지입니다.';
 
 const updateMessagesWithLimit = (prevMessages: Message[], newMessages: Message[]) => {
   const updatedMessages = [...prevMessages, ...newMessages];
@@ -92,7 +93,7 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
         .map(v => JSON.parse(v))
         .map(msg => ({
           ...msg,
-          content: msg.filteringResult ? msg.content : '클린봇이 삭제한 메세지입니다.',
+          content: msg.filteringResult ? msg.content : CLEAN_BOT_MESSAGE,
         }));
 
       if (isScrollPaused) {
@@ -168,14 +169,14 @@ export default function ChatWindow({ onAir, id }: ChatWindowProps) {
       setMessages(prevMessages => {
         const messageIndex = prevMessages.findIndex(msg => msg.chatId === filteredMessage.chatId);
 
-        if (messageIndex === -1 || prevMessages[messageIndex].content === '클린봇이 삭제한 메세지입니다.') {
+        if (messageIndex === -1 || prevMessages[messageIndex].content === CLEAN_BOT_MESSAGE) {
           return prevMessages;
         }
 
         const updatedMessages = [...prevMessages];
         updatedMessages[messageIndex] = {
           ...updatedMessages[messageIndex],
-          content: '클린봇이 삭제한 메세지입니다.',
+          content: CLEAN_BOT_MESSAGE,
           filteringResult: false,
         };
         return updatedMessages;

--- a/Frontend/src/components/common/Toggle/index.tsx
+++ b/Frontend/src/components/common/Toggle/index.tsx
@@ -11,7 +11,7 @@ function Toggle({ checked, onChange, className = '' }: ToggleProps) {
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-6 w-14 items-center rounded-full transition-colors duration-200 ease-in-out ${checked ? 'bg-lico-orange-1' : 'bg-lico-gray-3'} ${className}`}
     >
-      <div className="justi absolute inset-0 flex items-center font-medium text-xs">
+      <div className="absolute inset-0 flex items-center justify-between px-1.5 font-medium text-xs">
         <span
           className={`font-bold text-lico-gray-3 transition-opacity duration-200 ${checked ? 'opacity-100' : 'opacity-0'}`}
         >

--- a/Frontend/src/components/common/Toggle/index.tsx
+++ b/Frontend/src/components/common/Toggle/index.tsx
@@ -1,0 +1,35 @@
+interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+}
+
+function Toggle({ checked, onChange, className = '' }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-6 w-14 items-center rounded-full transition-colors duration-200 ease-in-out ${checked ? 'bg-lico-orange-1' : 'bg-lico-gray-3'} ${className}`}
+    >
+      <div className="justi absolute inset-0 flex items-center font-medium text-xs">
+        <span
+          className={`font-bold text-lico-gray-3 transition-opacity duration-200 ${checked ? 'opacity-100' : 'opacity-0'}`}
+        >
+          ON
+        </span>
+        <span
+          className={`font-bold text-lico-gray-1 transition-opacity duration-200 ${checked ? 'opacity-0' : 'opacity-100'}`}
+        >
+          OFF
+        </span>
+      </div>
+      <div
+        className={`${
+          checked ? 'translate-x-8' : 'translate-x-1'
+        } z-10 inline-block h-4 w-4 transform rounded-full bg-lico-gray-1 transition duration-300 ease-in-out`}
+      />
+    </button>
+  );
+}
+
+export default Toggle;

--- a/Frontend/src/types/live.ts
+++ b/Frontend/src/types/live.ts
@@ -54,4 +54,6 @@ export interface Message {
   nickname: string;
   content: string;
   timestamp: string;
+  chatId: string;
+  filteringResult: boolean;
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->

- 채팅 클린봇 모드를 구현했습니다.
- 채팅 헤더의 더보기 버튼을 통해 클린봇, 채팅 팝업 버튼에 접근할 수 있습니다.
- 클린 봇 모드는 토글 버튼을 통해 on/off를 할 수 있습니다.
- 공용 토글 버튼을 구현했습니다.

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

![클린봇](https://github.com/user-attachments/assets/038b137a-ad6a-4ef7-a1ae-00c65161f6a2)



## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #이슈번호
- resolves #이슈번호

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->

