### PR TITLE
[Feature]  모니터링을 위한 매트릭 추가

### DIFF
--- a/Backend/apps/api/src/app.module.ts
+++ b/Backend/apps/api/src/app.module.ts
@@ -18,6 +18,7 @@ import { WinstonModule } from 'nest-winston';
 import { winstonConfig } from './config/logger.config';
 import { APP_INTERCEPTOR, APP_FILTER } from '@nestjs/core';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { MetricsInterceptor } from './common/interceptors/metrics.interceptor';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 @Module({
@@ -50,6 +51,10 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
       {
       provide: APP_INTERCEPTOR,
       useClass: LoggingInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: MetricsInterceptor,
     },
     {
       provide: APP_FILTER,

--- a/Backend/apps/api/src/common/interceptors/metrics.interceptor.ts
+++ b/Backend/apps/api/src/common/interceptors/metrics.interceptor.ts
@@ -1,0 +1,73 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import axios from 'axios';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(private configService: ConfigService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const metricsEnabled = this.configService.get<boolean>('METRICS_ENABLED') || true;
+
+    if (!metricsEnabled) {
+      return next.handle();
+    }
+
+    const now = Date.now();
+    const request = context.switchToHttp().getRequest<Request>();
+    const { method, url } = request;
+
+    return next.handle().pipe(
+      tap(() => {
+        const responseTime = Date.now() - now;
+        // 메트릭 데이터 생성
+        const metricData = {
+          cw_key: this.configService.get<string>('NCLOUD_CW_KEY'),
+          dimensions: {
+            path: url,
+            method: method,
+          },
+          metrics: [
+            {
+              metric: 'api_response_time',
+              value: responseTime,
+              timestamp: Date.now(),
+            },
+            {
+              metric: 'api_request_count',
+              value: 1,
+              timestamp: Date.now(),
+            },
+          ],
+        };
+        // 비동기적으로 메트릭 전송
+        this.sendMetric(metricData);
+      }),
+    );
+  }
+
+  private async sendMetric(metricData: any) {
+    try {
+      await axios.post(
+        this.configService.get<string>('NCLOUD_API_ENDPOINT'), // .env에 설정한 엔드포인트 URL 사용
+        metricData,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'x-ncp-apigw-api-key': this.configService.get<string>('NCLOUD_API_KEY'),
+          },
+        },
+      );
+    } catch (error) {
+      console.error('Metric send error:', error);
+      // 메트릭 전송 실패 시 애플리케이션 동작에 영향을 주지 않도록 처리
+    }
+  }
+}

--- a/Backend/apps/api/src/common/interceptors/metrics.interceptor.ts
+++ b/Backend/apps/api/src/common/interceptors/metrics.interceptor.ts
@@ -8,13 +8,14 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
 
 @Injectable()
 export class MetricsInterceptor implements NestInterceptor {
   constructor(private configService: ConfigService) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    const metricsEnabled = this.configService.get<boolean>('METRICS_ENABLED') || true;
+    const metricsEnabled = this.configService.get<boolean>('METRICS_ENABLED') ?? true;
 
     if (!metricsEnabled) {
       return next.handle();
@@ -27,47 +28,95 @@ export class MetricsInterceptor implements NestInterceptor {
     return next.handle().pipe(
       tap(() => {
         const responseTime = Date.now() - now;
+
+        // ID Dimension 및 추가 Dimension 값 설정
+        const path = this.extractPath(url);
+
         // 메트릭 데이터 생성
         const metricData = {
-          cw_key: this.configService.get<string>('NCLOUD_CW_KEY'),
-          dimensions: {
-            path: url,
-            method: method,
-          },
-          metrics: [
+          metricList: [
             {
+              productName: this.configService.get<string>('NCLOUD_PRODUCT_NAME'),
               metric: 'api_response_time',
-              value: responseTime,
-              timestamp: Date.now(),
+              dimensions: {
+                path: path,
+                method: method,
+              },
+              values: [
+                {
+                  timestamp: Date.now(),
+                  value: responseTime,
+                },
+              ],
             },
             {
+              productName: this.configService.get<string>('NCLOUD_PRODUCT_NAME'),
               metric: 'api_request_count',
-              value: 1,
-              timestamp: Date.now(),
+              dimensions: {
+                path: path,
+                method: method,
+              },
+              values: [
+                {
+                  timestamp: Date.now(),
+                  value: 1,
+                },
+              ],
             },
           ],
         };
+
         // 비동기적으로 메트릭 전송
-        this.sendMetric(metricData);
+        this.sendMetric(metricData).catch((error) => {
+          console.error('Metric send error:', error);
+        });
       }),
     );
   }
 
+  private extractPath(url: string): string {
+    try {
+      const parsedUrl = new URL(url, `http://${process.env.HOSTNAME || 'localhost'}`);
+      return parsedUrl.pathname;
+    } catch (error) {
+      console.error('URL parsing error:', error);
+      return '/unknown';
+    }
+  }
+
   private async sendMetric(metricData: any) {
     try {
+      const accessKey = this.configService.get<string>('NCLOUD_ACCESS_KEY');
+      const secretKey = this.configService.get<string>('NCLOUD_SECRET_KEY');
+      const timestamp = Date.now().toString();
+      const method = 'POST';
+      const uri = '/cw_server/real/cw/api/data';
+
+      const signature = this.makeSignature(method, uri, timestamp, accessKey, secretKey);
+
       await axios.post(
-        this.configService.get<string>('NCLOUD_API_ENDPOINT'), // .env에 설정한 엔드포인트 URL 사용
+        `https://cw.apigw.ntruss.com${uri}`,
         metricData,
         {
           headers: {
-            'Content-Type': 'application/json',
-            'x-ncp-apigw-api-key': this.configService.get<string>('NCLOUD_API_KEY'),
+            'Content-Type': 'application/json;charset=UTF-8',
+            'x-ncp-apigw-timestamp': timestamp,
+            'x-ncp-iam-access-key': accessKey,
+            'x-ncp-apigw-signature-v2': signature,
           },
         },
       );
     } catch (error) {
-      console.error('Metric send error:', error);
+      console.error('Error sending metrics:', error);
       // 메트릭 전송 실패 시 애플리케이션 동작에 영향을 주지 않도록 처리
     }
+  }
+
+  private makeSignature(method: string, url: string, timestamp: string, accessKey: string, secretKey: string): string {
+    const space = ' ';
+    const newLine = '\n';
+    const message = method + space + url + newLine + timestamp + newLine + accessKey;
+    const hmac = crypto.createHmac('sha256', secretKey);
+    return hmac.update(message).digest('base64');
   }
 }


### PR DESCRIPTION
## 📝 PR 설명
api 호출에 대한 모니터링을 위해 인터셉터에서 매트릭을 추가했습니다.

###현재 구현된 메트릭
**api_response_time**

설명: API 요청이 처리되는 데 걸린 시간(응답 시간)을 측정합니다.
용도: 애플리케이션의 성능을 모니터링하고, 특정 엔드포인트의 응답 속도가 느려지는 경우 원인을 분석하는 데 유용합니다.
코드 예시:
```
{
  metric: 'api_response_time',
  value: responseTime, // 요청 처리 시간 (밀리초 단위)
  timestamp: Date.now(),
}
```
**api_request_count**

설명: 특정 API 엔드포인트에 대한 요청 수를 카운트합니다.
용도: API 사용량을 모니터링하고, 특정 엔드포인트의 트래픽 패턴을 분석하는 데 도움이 됩니다.
코드 예시:
```
{
  metric: 'api_request_count',
  value: 1, // 단일 요청 카운트
  timestamp: Date.now(),
}
```

추신 : 원래 프로메테우스하고 그라파나로 시스템을 구축하려고 했는데, 잘 안 되어서 ncloud cloud insigth 를 활용해볼 생각입니다. 이로 인해서 환경 변수 추가가 있습니다.
```
// 추가된 환경 변수 예시
NCLOUD_CW_KEY=your_custom_schema_key
NCLOUD_API_KEY=your_generated_api_key
NCLOUD_API_ENDPOINT=http://localhost:4000/metrics
METRICS_ENABLED=true
```
## ✅ 주요 변경 사항
- [ ] 매트릭을 위한 인터셉터 추가

## 📸 스크린샷 (
로컬에서 매트릭 전송 확인
![매트릭 전송 확인](https://github.com/user-attachments/assets/761d5ea1-257a-4bcf-84e0-c049abca22f0)
선택)


## 🔗 관련 이슈


## 🛠️ 추가 작업 (선택)

