### PR TITLE
[Feature] : 가계정 기능 구현

### DIFF
--- a/Backend/apps/api/src/auth/auth.controller.ts
+++ b/Backend/apps/api/src/auth/auth.controller.ts
@@ -34,6 +34,12 @@ export class AuthController {
     return this.handleOAuthCallback(req, res);
   }
 
+  @Get('lico/callback')
+  @UseGuards(AuthGuard('lico'))
+  async licoAuthCallback(@Req() req: Request & { user: any }, @Res() res: Response) {
+    return this.handleOAuthCallback(req, res);
+  }
+
   @Get('logout')
   @UseGuards(JwtAuthGuard)
   async logout(@Req() req: Request, @Res() res: Response) {

--- a/Backend/apps/api/src/auth/auth.module.ts
+++ b/Backend/apps/api/src/auth/auth.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
-import { PassportModule } from '@nestjs/passport'; // PassportModule 추가
+import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { UsersModule } from '../users/users.module';
@@ -10,6 +10,7 @@ import { GithubStrategy } from './strategies/github.strategy';
 import { NaverStrategy } from './strategies/naver.strategy';
 import { ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './strategies/jwt.strategy'; 
+import { LicoStrategy } from './strategies/lico.strategy';
 
 @Module({
   imports: [
@@ -28,10 +29,11 @@ import { JwtStrategy } from './strategies/jwt.strategy';
   controllers: [AuthController],
   providers: [
     AuthService,
-    GoogleStrategy, // 추가
-    GithubStrategy, // 추가
-    NaverStrategy, // 추가
+    GoogleStrategy,
+    GithubStrategy,
+    NaverStrategy,
     JwtStrategy,
+    LicoStrategy,
   ],
   exports: [AuthService],
 })

--- a/Backend/apps/api/src/auth/auth.service.ts
+++ b/Backend/apps/api/src/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { ConfigService } from '@nestjs/config';
 
-type OAuthPlatform = 'google' | 'github' | 'naver'; // platform 타입 정의 추가
+type OAuthPlatform = 'google' | 'github' | 'naver';
 
 @Injectable()
 export class AuthService {
@@ -15,7 +15,7 @@ export class AuthService {
 
   async validateOAuthLogin(
     oauthUid: string,
-    oauthPlatform: OAuthPlatform, // 타입 수정
+    oauthPlatform: OAuthPlatform,
     profileData: {
       nickname: string;
       profileImage?: string;

--- a/Backend/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/Backend/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -24,7 +24,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     const user = await this.usersService.findById(id);
   
     if (user && user.oauthPlatform === provider) {
-      return user; // req.user에 사용자 정보 첨부
+      return user;
     }
     return null;
   }

--- a/Backend/apps/api/src/auth/strategies/lico.strategy.ts
+++ b/Backend/apps/api/src/auth/strategies/lico.strategy.ts
@@ -1,0 +1,25 @@
+import { Strategy } from 'passport-custom';
+import { PassportStrategy } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class LicoStrategy extends PassportStrategy(Strategy, 'lico') {
+  async validate(req: Request, done: Function) {
+    try {
+      const oauthUid = crypto.randomBytes(16).toString('hex');
+
+      const userData = {
+        oauthUid,
+        provider: 'lico' as 'lico',
+        nickname: `User_${oauthUid.substring(0, 8)}`,
+        profileImage: null,
+        email: null,
+      };
+
+      done(null, userData);
+    } catch (error) {
+      done(error, false);
+    }
+  }
+}

--- a/Backend/apps/api/src/users/entity/user.entity.ts
+++ b/Backend/apps/api/src/users/entity/user.entity.ts
@@ -23,10 +23,10 @@ export class UserEntity {
   @Column({
     name: 'oauth_platform',
     type: 'enum',
-    enum: ['naver', 'github', 'google'],
+    enum: ['naver', 'github', 'google', 'lico'],
     nullable: false,
   })
-  oauthPlatform: 'naver' | 'github' | 'google';
+  oauthPlatform: 'naver' | 'github' | 'google'| 'lico';
 
   @Column({ name: 'users_nickname', type: 'varchar', length: 50 })
   nickname: string;

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -32,6 +32,7 @@
         "mysql2": "^3.11.3",
         "nest-winston": "^1.9.7",
         "passport": "^0.7.0",
+        "passport-custom": "^1.1.1",
         "passport-github2": "^0.1.12",
         "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
@@ -12518,6 +12519,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-custom": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/passport-custom/-/passport-custom-1.1.1.tgz",
+      "integrity": "sha512-/2m7jUGxmCYvoqenLB9UrmkCgPt64h8ZtV+UtuQklZ/Tn1NpKBeOorCYkB/8lMRoiZ5hUrCoMmDtxCS/d38mlg==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/passport-github2": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -43,6 +43,7 @@
     "mysql2": "^3.11.3",
     "nest-winston": "^1.9.7",
     "passport": "^0.7.0",
+    "passport-custom": "^1.1.1",
     "passport-github2": "^0.1.12",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",


### PR DESCRIPTION
## 📝 PR 설명
- `/auth/lico/callback` 엔드포인트를 추가하여 우리 서비스인 lico의 간단한 회원가입 및 로그인 기능을 구현하였습니다.
  -   [api 문서 참고](https://far-woodwind-e60.notion.site/auth-provider-callback-c3110eda21fe4a25a826614c09981917?pvs=4)
- 이를 위해 `passport-custom` 모듈을 설치하고, LicoStrategy를 생성하여 기존의 OAuth 전략과 통합하였습니다.
  - **passport-custom**은 Passport.js에서 커스텀 인증 전략을 구현할 수 있게 해주는 모듈입니다.
  - NestJS에서 기본 제공되는 인증 전략 외에, 특정 요구사항에 맞는 커스텀 인증 로직을 구현해야 할 때 **passport-custom**을 사용하는 것이 권장됩니다.
- LicoStrategy는 요청 시 랜덤한 사용자 ID를 생성하고, 회원가입과 로그인을 동시에 처리합니다.
- 구조 상 그냥 db에 정보가 생성됩니다. 그리고 매번 요청하면 무한 생성되는 문제가 있습니다.

## ✅ 주요 변경 사항
- `/auth/lico/callback` 엔드포인트 추가 및 관련 로직 구현
-  passport-custom 모듈 설치 및 LicoStrategy 생성
- AuthModule, AuthController에 LicoStrategy 등록 및 적용
- UserEntity의 oauthPlatform에 'lico' 옵션 추가
- 기존 코드와의 통합 및 엔드포인트 일관성 유지


## 📸 스크린샷 (선택)
### postman test
![lico_access](https://github.com/user-attachments/assets/7118bd79-acc0-4e85-8748-db7152aff2b6)

![lico_refresh](https://github.com/user-attachments/assets/b2f9fe2d-d44c-43ab-b923-af13063227d8)

### local 의 db 값 추가 확인
users 테이블
![db_save](https://github.com/user-attachments/assets/48bdee26-95d2-4705-a11b-2e00cde01782)
lives 테이블
![image](https://github.com/user-attachments/assets/fa074492-c19c-4906-8467-d00b703b427f)



## 🔗 관련 이슈


## 🛠️ 추가 작업 (선택)

