### PR TITLE
[Feature] 팔로워 수, 카테고리 페이지 라이브와 시청자 수 api 연결

### DIFF
--- a/Frontend/src/apis/follow.ts
+++ b/Frontend/src/apis/follow.ts
@@ -16,4 +16,9 @@ export const followApi = {
     const { data } = await api.delete(`/follow/${streamerId}`);
     return data;
   },
+
+  getFollowerCount: async (streamerId: number) => {
+    const { data } = await api.get(`/follow/count/${streamerId}`);
+    return data;
+  },
 };

--- a/Frontend/src/components/category/CategoryCard/index.tsx
+++ b/Frontend/src/components/category/CategoryCard/index.tsx
@@ -6,11 +6,11 @@ export interface CategoryCardProps {
   id: number;
   name: string;
   image: string;
-  totalViewers?: number;
-  totalLives?: number;
+  totalViewers: number;
+  totalLives: number;
 }
 
-export default function CategoryCard({ id, name, image, totalViewers = 0, totalLives = 0 }: CategoryCardProps) {
+export default function CategoryCard({ id, name, image, totalViewers, totalLives }: CategoryCardProps) {
   const navigate = useNavigate();
 
   const handleClick = () => {

--- a/Frontend/src/components/category/CategoryCard/index.tsx
+++ b/Frontend/src/components/category/CategoryCard/index.tsx
@@ -18,7 +18,7 @@ export default function CategoryCard({ id, name, image, totalViewers = 0, totalL
   };
 
   return (
-    <div className="mb-3 cursor-pointer" onClick={handleClick}>
+    <button type="button" className="mb-3 cursor-pointer text-left" onClick={handleClick}>
       <div className="relative inline-block w-full">
         <img src={image} alt={name} className="aspect-[3/4] w-[calc(20vw-12px)] rounded-xl object-cover" />
         <div className="absolute left-1.5 top-1.5 flex items-center gap-1 rounded-[4px] bg-black bg-opacity-60 px-1">
@@ -30,6 +30,6 @@ export default function CategoryCard({ id, name, image, totalViewers = 0, totalL
         <p className="font-bold text-sm text-lico-gray-1">{name}</p>
         <p className="font-medium text-xs text-lico-gray-2">라이브 {totalLives}개</p>
       </div>
-    </div>
+    </button>
   );
 }

--- a/Frontend/src/hooks/useFollow.ts
+++ b/Frontend/src/hooks/useFollow.ts
@@ -53,3 +53,10 @@ export const useFollow = () => {
     isFollowed,
   };
 };
+
+export const useFollowerCount = (streamerId: number) => {
+  return useQuery({
+    queryKey: ['followerCount', streamerId],
+    queryFn: () => followApi.getFollowerCount(streamerId),
+  });
+};

--- a/Frontend/src/pages/CategoryPage/index.tsx
+++ b/Frontend/src/pages/CategoryPage/index.tsx
@@ -16,8 +16,8 @@ export default function CategoryPage() {
           id: category.id,
           name: category.name,
           image: category.image,
-          totalViewers: 0,
-          totalLives: 0,
+          totalViewers: category.viewerCount,
+          totalLives: category.liveCount,
         }))}
       />
     </div>

--- a/Frontend/src/pages/FollowingPage/index.tsx
+++ b/Frontend/src/pages/FollowingPage/index.tsx
@@ -15,7 +15,7 @@ export default function FollowingPage() {
       categoryId: follow.categoriesId,
       profileImgUrl: follow.usersProfileImage,
       thumbnailUrl: `${config.storageUrl}/${follow.channelId}/thumbnail.jpg`,
-      viewers: 0,
+      viewers: follow.viewers,
       isLive: follow.onAir,
       createdAt: new Date().toISOString(),
     })) ?? [];

--- a/Frontend/src/pages/LivePage/LiveInfo.tsx
+++ b/Frontend/src/pages/LivePage/LiveInfo.tsx
@@ -1,9 +1,8 @@
+import { useState } from 'react';
 import { LuUser } from 'react-icons/lu';
+import { formatNumber } from '@utils/format';
 import CategoryBadge from '@components/common/Badges/CategoryBadge';
 import FollowButton from '@components/common/Buttons/FollowButton';
-import { useState } from 'react';
-
-import { formatNumber } from '@utils/format';
 import StreamingTimer from '@pages/LivePage/StreamingTimer';
 
 interface LiveInfoProps {

--- a/Frontend/src/pages/LivePage/StreamerInfo.tsx
+++ b/Frontend/src/pages/LivePage/StreamerInfo.tsx
@@ -1,17 +1,20 @@
 import { formatNumber } from '@utils/format';
+import { useFollowerCount } from '@hooks/useFollow.ts';
 
 interface StreamerInfoProps {
   streamerName: string;
-  followers: number;
+  streamerId: number;
   channelDescription: string;
 }
 
-export default function StreamerInfo({ streamerName, followers, channelDescription }: StreamerInfoProps) {
+export default function StreamerInfo({ streamerName, streamerId, channelDescription }: StreamerInfoProps) {
+  const { data: { followerCount } = { followerCount: 0 } } = useFollowerCount(streamerId);
+
   return (
     <div className="w-full p-3">
       <div className="flex items-center gap-3">
         <div className="font-bold text-lg text-lico-orange-2">{streamerName}</div>
-        <div className="font-medium text-sm text-lico-gray-2">팔로워 {formatNumber(followers)}명</div>
+        <div className="font-medium text-sm text-lico-gray-2">팔로워 {formatNumber(followerCount)}명</div>
       </div>
       <div className="font-medium text-lico-gray-1">{channelDescription}</div>
     </div>

--- a/Frontend/src/pages/LivePage/index.tsx
+++ b/Frontend/src/pages/LivePage/index.tsx
@@ -72,7 +72,7 @@ export default function LivePage() {
               <StreamerInfo
                 streamerName={liveDetail.usersNickname}
                 channelDescription={currentDescription}
-                followers={0}
+                streamerId={liveDetail.streamerId}
               />
             </>
           )}

--- a/Frontend/src/pages/StudioPage/StreamInfo.tsx
+++ b/Frontend/src/pages/StudioPage/StreamInfo.tsx
@@ -13,7 +13,7 @@ import { useUpdateLive } from '@hooks/useLive';
 
 import { useAuthStore } from '@store/useAuthStore';
 import { CATEGORIES } from '@constants/categories';
-import type { Category } from '@/types/category';
+import type { BaseCategory } from '@/types/category';
 
 interface StreamInfoProps {
   channelId: string;
@@ -25,7 +25,7 @@ export default function StreamInfo({ channelId }: StreamInfoProps) {
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<BaseCategory | null>(null);
 
   const [toastMessage, setToastMessage] = useState('');
   const [showToast, setShowToast] = useState(false);
@@ -54,7 +54,7 @@ export default function StreamInfo({ channelId }: StreamInfoProps) {
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleCategorySelect = (category: Category) => {
+  const handleCategorySelect = (category: BaseCategory) => {
     setSelectedCategory(category);
   };
 

--- a/Frontend/src/pages/StudioPage/StreamInfo.tsx
+++ b/Frontend/src/pages/StudioPage/StreamInfo.tsx
@@ -7,9 +7,8 @@ import CategoryBadge from '@components/common/Badges/CategoryBadge';
 import Toast from '@components/common/Toast';
 
 import { useClickOutside } from '@hooks/useClickOutside';
-import { useLiveDetail } from '@hooks/useLive';
+import { useLiveDetail, useUpdateLive } from '@hooks/useLive';
 import { useSearch } from '@hooks/useSearch';
-import { useUpdateLive } from '@hooks/useLive';
 
 import { useAuthStore } from '@store/useAuthStore';
 import { CATEGORIES } from '@constants/categories';

--- a/Frontend/src/types/category.ts
+++ b/Frontend/src/types/category.ts
@@ -2,4 +2,6 @@ export interface Category {
   id: number;
   name: string;
   image: string;
+  viewerCount: number;
+  liveCount: number;
 }

--- a/Frontend/src/types/category.ts
+++ b/Frontend/src/types/category.ts
@@ -1,7 +1,10 @@
-export interface Category {
+export interface BaseCategory {
   id: number;
   name: string;
   image: string;
+}
+
+export interface Category extends BaseCategory {
   viewerCount: number;
   liveCount: number;
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->

- 라이브 페이지 스트리머 정보란에 팔로워 수가 표시됩니다.
- 카테고리 페이지의 카테고리 별 시청자 수와 라이브 방송 개수가 표시됩니다.
- 팔로우 페이지 채널 카드의 시청자 수가 표시됩니다.

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->


## 📸 스크린샷 (선택)
<!-- 변경 사항을 보여줄 수 있는 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요. -->

- closes #이슈번호
- resolves #이슈번호

## 🛠️ 추가 작업 (선택)
<!-- 추가로 해야 할 작업이 있다면 작성해주세요. -->
