### PR TITLE
[Fix] 방송 진행 중 여부 획득 API 추가 및 방송 시작 시 viewers 초기화 하도록 변경

### DIFF
--- a/Backend/apps/api/src/chats/chats.service.ts
+++ b/Backend/apps/api/src/chats/chats.service.ts
@@ -45,8 +45,7 @@ export class ChatsService {
   }
 
   async clearChat(channelId: UUID) {
-    this.redisClient.del(`${channelId}:viewers`);
-    this.redisClient.del(`${channelId}:chats`);
+    this.redisClient.multi().del(`${channelId}:viewers`).del(`${channelId}:chats`).exec();
   }
 
   async clovaFiltering(chat) {

--- a/Backend/apps/api/src/chats/chats.service.ts
+++ b/Backend/apps/api/src/chats/chats.service.ts
@@ -45,6 +45,7 @@ export class ChatsService {
   }
 
   async clearChat(channelId: UUID) {
+    this.redisClient.del(`${channelId}:viewers`);
     this.redisClient.del(`${channelId}:chats`);
   }
 

--- a/Backend/apps/api/src/lives/lives.controller.ts
+++ b/Backend/apps/api/src/lives/lives.controller.ts
@@ -76,7 +76,7 @@ export class LivesController {
 
   @Get('/onair/:streamingKey')
   async getOnAir(@Param('streamingKey') streamingKey: UUID) {
-    this.livesService.readOnAir(streamingKey);
+    return await this.livesService.readOnAir(streamingKey);
   }
 
   @Get('/status/:channelId')

--- a/Backend/apps/api/src/lives/lives.controller.ts
+++ b/Backend/apps/api/src/lives/lives.controller.ts
@@ -74,6 +74,11 @@ export class LivesController {
     this.livesService.endLive(streamingKey);
   }
 
+  @Get('/onair/:streamingKey')
+  async getOnAir(@Param('streamingKey') streamingKey: UUID) {
+    this.livesService.readOnAir(streamingKey);
+  }
+
   @Get('/status/:channelId')
   async getStatus(@Param('channelId') channelId: UUID): Promise<StatusDto> {
     return await this.livesService.readStatus(channelId);

--- a/Backend/apps/api/src/lives/lives.service.ts
+++ b/Backend/apps/api/src/lives/lives.service.ts
@@ -190,6 +190,6 @@ export class LivesService {
 
   async readOnAir(streamingKey: UUID) {
     const live = await this.livesRepository.findOne({ where: { streamingKey } });
-    return live.onAir;
+    return { onAir: live.onAir };
   }
 }

--- a/Backend/apps/api/src/lives/lives.service.ts
+++ b/Backend/apps/api/src/lives/lives.service.ts
@@ -27,7 +27,6 @@ export class LivesService {
     private chatsService: ChatsService,
     @InjectRedis() private redisClient: Redis,
   ) {
-    this.redisClient.flushall();
     this.redisClient.config('SET', 'notify-keyspace-events', 'Ex');
     const subscriber = this.redisClient.duplicate();
     subscriber.subscribe('__keyevent@0__:expired');
@@ -187,5 +186,10 @@ export class LivesService {
       liveCount: Number(stats.liveCount) || 0,
       viewerCount: Number(stats.viewerCount) || 0,
     };
+  }
+
+  async readOnAir(streamingKey: UUID) {
+    const live = await this.livesRepository.findOne({ where: { streamingKey } });
+    return live.onAir;
   }
 }


### PR DESCRIPTION
## 📝 PR 설명
<!-- 구현한 기능이나 수정한 사항에 대해 상세히 설명해주세요. -->
웹스튜디오로 WHIP 요청을 보내기 전에 방송이 진행중인지 여부를 체크할 수 있도록 방송 진행상태 획득 API 추가
방송 시작 시 시청자 수 초기화 추가, multi로 채팅 초기화와 연속적으로 수행되도록 변경

## ✅ 주요 변경 사항
<!-- 변경된 주요 사항을 체크리스트로 작성해주세요. -->

- GET /lives/onair/:streamingKey 방송 진행 상태 획득 API 추가
- 방송 시작 시 시청자 수 초기화