### PR TITLE
[Feature] 가계정 임시 프로필 설정

### DIFF
--- a/Backend/apps/api/src/auth/strategies/lico.strategy.ts
+++ b/Backend/apps/api/src/auth/strategies/lico.strategy.ts
@@ -19,7 +19,7 @@ export class LicoStrategy extends PassportStrategy(Strategy, 'lico') {
         oauthUid,
         provider: 'lico' as 'lico',
         nickname,
-        profileImage: null,
+        profileImage: `https://kr.object.ncloudstorage.com/lico.image/default-profile-image/lico_profile.png`,
         email: null,
       };
 


### PR DESCRIPTION
## 📝 PR 설명
가계정(`auth/lico/guest`) 로 임시 계정 생성 시 프로필이 `null` 이였습니다. 가계정도 profile 이미지를 더미로 넣어달라는 요청이 있었습니다. 일단은, 개발 편의상 저희 lico 아이콘 하나만 추가합니다. 

오늘 이것도 여러 개의 랜덤 이미지로 프로필이 생성되도록 구현하겠습니다.

## ✅ 주요 변경 사항
- [ ] 가계정 프로필이 `null` 에서 더미 이미지로 수정


## 📸 스크린샷 (선택)
### 현재 프로필 이미지(이거 한 개로 통일됨)

![lico_profile](https://kr.object.ncloudstorage.com/lico.image/default-profile-image/lico_profile.png)


## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)
