### PR TITLE
[Feature] 가계정  프로필 이미지 랜덤 생성

### DIFF
--- a/Backend/apps/api/src/auth/strategies/lico.strategy.ts
+++ b/Backend/apps/api/src/auth/strategies/lico.strategy.ts
@@ -15,11 +15,13 @@ export class LicoStrategy extends PassportStrategy(Strategy, 'lico') {
       const randomNoun = nouns[Math.floor(Math.random() * nouns.length)];
       const nickname = `${randomAdjective} ${randomNoun}`;
 
+      const profileNumber = Math.floor(Math.random() * 31)
+
       const userData = {
         oauthUid,
         provider: 'lico' as 'lico',
         nickname,
-        profileImage: `https://kr.object.ncloudstorage.com/lico.image/default-profile-image/lico_profile.png`,
+        profileImage: `https://kr.object.ncloudstorage.com/lico.image/default-profile-image/lico_${profileNumber}.png`,
         email: null,
       };
 

--- a/Backend/apps/api/src/lives/entity/live.entity.ts
+++ b/Backend/apps/api/src/lives/entity/live.entity.ts
@@ -14,12 +14,16 @@ import {
 import { LivesDto } from '../dto/lives.dto';
 import { LiveDto } from '../dto/live.dto';
 import { StatusDto } from '../dto/status.dto';
+import { Index } from 'typeorm';
 
+
+@Index(['onAir', 'categoriesId'])
 @Entity('lives')
 export class LiveEntity {
   @PrimaryGeneratedColumn({ name: 'lives_id' })
   id: number;
 
+  @Index()
   @Column({ name: 'categories_id', type: 'int', nullable: true })
   categoriesId: number | null;
 
@@ -39,6 +43,7 @@ export class LiveEntity {
   @Column({ name: 'streaming_key', type: 'varchar', length: 36 })
   streamingKey: string;
 
+  @Index()
   @Column({ name: 'onair', type: 'boolean', nullable: true })
   onAir: boolean | null;
 


### PR DESCRIPTION
## 📝 PR 설명
가계정으로 로그인 및 회원가입을 시도하면 임시 프로필 이미지를 생성합니다. 저희 lico 아이콘에서 색깔만 다른 것을 30개 만들었습니다(ppt 활용). 0~30 의 랜덤값을 받아서 기본 프로필 이미지로 사용합니다.

개발 일지 작성하는 김에 집계 쿼리로 속도 개선한 내용을 작성하고 있었습니다. 여러가지 시도했는데 결론이 index 여서 추가합니다. 

## ✅ 주요 변경 사항
- [ ] 랜덤 프로필 이미지 생성
- [ ] live entity 인덱스 추가

## 📸 스크린샷 (선택)
![랜덤_프로필_이미지](https://github.com/user-attachments/assets/96894038-4159-4296-875f-6fd79009c568)
![image](https://github.com/user-attachments/assets/4e33f412-6ffb-4dca-afbe-a3b557891fd9)


## 🔗 관련 이슈

## 🛠️ 추가 작업 (선택)

